### PR TITLE
Built ns_connection data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.1 (Nov 05, 2020)
+
+FEATURES:
+
+* Created data source `ns_connection`.
+
 ## 0.1.0 (Oct 28, 2020)
 
 FEATURES:

--- a/internal/provider/data_source_ns_connection.go
+++ b/internal/provider/data_source_ns_connection.go
@@ -1,0 +1,67 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var validConnectionName = regexp.MustCompile("^[_a-z0-9/-]+$")
+
+func dataSourceNsConnection() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNsConnectionRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The unique name of the connection within this module.",
+				ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
+					val, ok := i.(string)
+					if !ok {
+						return diag.Errorf("ns_connection.name must be a string")
+					}
+					if !validConnectionName.Match([]byte(val)) {
+						return diag.Errorf("ns_connection.name can only contain the characters 'a'-'z', '0'-'9', '-', '_'")
+					}
+					return nil
+				},
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The type of module to satisfy this connection.",
+			},
+			"optional": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "This data source will cause an error if optional is false and this connection is not configured.",
+			},
+			"workspace": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the connected workspace.",
+			},
+		},
+	}
+}
+
+func dataSourceNsConnectionRead(d *schema.ResourceData, meta interface{}) error {
+	name := d.Get("name").(string)
+	optional := d.Get("optional").(bool)
+
+	workspace := os.Getenv(fmt.Sprintf("NULLSTONE_CONNECTION_%s", name))
+	if workspace == "" && !optional {
+		return fmt.Errorf("The connection %q is missing. It is required to use this plan.", name)
+	}
+	d.Set("workspace", workspace)
+	d.SetId(fmt.Sprintf("%s-%s", name, workspace))
+
+	return nil
+}

--- a/internal/provider/data_source_ns_connection.go
+++ b/internal/provider/data_source_ns_connection.go
@@ -48,6 +48,12 @@ func dataSourceNsConnection() *schema.Resource {
 				Computed:    true,
 				Description: "The name of the connected workspace.",
 			},
+			"via": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Defines this connection is satisfied through another ns_connection.
+Typically, this is set to data.ns_connection.other.workspace.`,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_ns_connection_test.go
+++ b/internal/provider/data_source_ns_connection_test.go
@@ -1,0 +1,84 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccNsConnectionDataSource(t *testing.T) {
+	t.Run("fails when required and connection is not configured", func(t *testing.T) {
+		config := fmt.Sprintf(`
+data "ns_connection" "network" {
+  name = "network"
+  type = "aws/network"
+}
+`)
+		checks := resource.ComposeTestCheckFunc()
+
+		resource.UnitTest(t, resource.TestCase{
+			PreCheck:          func() { testAccPreCheck(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      config,
+					Check:       checks,
+					ExpectError: regexp.MustCompile(`The connection "network" is missing.`),
+				},
+			},
+		})
+	})
+
+	t.Run("sets empty attributes when optional and connection is not configured", func(t *testing.T) {
+		config := fmt.Sprintf(`
+data "ns_connection" "service" {
+  name     = "service"
+  type     = "fargate/service"
+  optional = true
+}
+`)
+		checks := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("data.ns_connection.service", `workspace`, ""),
+		)
+
+		resource.UnitTest(t, resource.TestCase{
+			PreCheck:          func() { testAccPreCheck(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check:  checks,
+				},
+			},
+		})
+
+	})
+
+	t.Run("sets up attributes properly", func(t *testing.T) {
+		config := fmt.Sprintf(`
+data "ns_connection" "service" {
+  name = "service"
+  type = "fargate/service"
+}
+`)
+		checks := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("data.ns_connection.service", `workspace`, "lycan"),
+		)
+
+		os.Setenv("NULLSTONE_CONNECTION_service", "lycan")
+
+		resource.UnitTest(t, resource.TestCase{
+			PreCheck:          func() { testAccPreCheck(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check:  checks,
+				},
+			},
+		})
+	})
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -11,7 +11,8 @@ func New(version string) func() *schema.Provider {
 	return func() *schema.Provider {
 		p := &schema.Provider{
 			DataSourcesMap: map[string]*schema.Resource{
-				"ns_workspace": dataSourceNsWorkspace(),
+				"ns_workspace":  dataSourceNsWorkspace(),
+				"ns_connection": dataSourceNsConnection(),
 			},
 			ResourcesMap: map[string]*schema.Resource{},
 		}

--- a/website/docs/d/ns_connection.html.markdown
+++ b/website/docs/d/ns_connection.html.markdown
@@ -1,0 +1,29 @@
+---
+layout: "ns"
+page_title: "Nullstone: ns_connection"
+sidebar_current: "docs-ns-connection"
+description: |-
+  Data source to configure a connection to another nullstone workspace.
+---
+
+# ns_connection
+
+Data source to configure connection to another nullstone workspace.
+This stanza defines the name and type of connection we need.
+During terraform execution, nullstone provides outputs from the connected workspace.
+
+## Example Usage
+
+```hcl
+data "ns_connection" "network" {
+  name = "network"
+  type = "aws/network"
+}
+```
+
+## Attributes Reference
+
+* `name` - Name of nullstone connection.
+* `type` - Type of nullstone module to make connection.
+* `optional` - By default, if this connection has not been configured, this causes an error. Set to true to disable. (Default: `false`)
+* `workspace` - Name of workspace for connection. (Environment variable: `NULLSTONE_CONNECTION_{name}`)

--- a/website/docs/d/ns_connection.html.markdown
+++ b/website/docs/d/ns_connection.html.markdown
@@ -15,9 +15,25 @@ During terraform execution, nullstone provides outputs from the connected worksp
 ## Example Usage
 
 ```hcl
+# Simple example
 data "ns_connection" "network" {
   name = "network"
-  type = "aws/network"
+  type = "network/aws"
+}
+```
+
+
+```hcl
+# Example using `via`
+data "ns_connection" "cluster" {
+  name = "cluster"
+  type = "cluster/aws-fargate"
+}
+
+data "ns_connection" "network" {
+  name = "network"
+  type = "network/aws"
+  via  = data.ns_connection.cluster.workspace
 }
 ```
 
@@ -27,3 +43,4 @@ data "ns_connection" "network" {
 * `type` - Type of nullstone module to make connection.
 * `optional` - By default, if this connection has not been configured, this causes an error. Set to true to disable. (Default: `false`)
 * `workspace` - Name of workspace for connection. (Environment variable: `NULLSTONE_CONNECTION_{name}`)
+* `via` - Name of workspace to satisfy this connection through. Typically, this is set to `data.ns_connection.other.workspace`.


### PR DESCRIPTION
This PR introduces `ns_connection` to define connected workspaces in lieu of terraform remote state.