### PR TITLE
Fixed several issues

### DIFF
--- a/internal/provider/data_connection.go
+++ b/internal/provider/data_connection.go
@@ -104,7 +104,7 @@ func (d *dataConnection) Validate(ctx context.Context, config map[string]tftypes
 		})
 	}
 
-	workspace := d.p.PlanConfig.GetConnection(name)
+	workspace := d.p.PlanConfig.GetConnectionWorkspace(name)
 	if workspace == "" && !optional {
 		diags = append(diags, &tfprotov5.Diagnostic{
 			Severity: tfprotov5.DiagnosticSeverityError,
@@ -128,7 +128,7 @@ func (d *dataConnection) Read(ctx context.Context, config map[string]tftypes.Val
 	diags := make([]*tfprotov5.Diagnostic, 0)
 
 	outputsValue := tftypes.NewValue(tftypes.Map{AttributeType: tftypes.String}, map[string]tftypes.Value{})
-	workspace := d.p.PlanConfig.GetConnection(name)
+	workspace := d.p.PlanConfig.GetConnectionWorkspace(name)
 	if workspace != "" {
 		stateFile, err := d.getStateFile(workspace)
 		if err != nil {

--- a/internal/provider/data_connection_test.go
+++ b/internal/provider/data_connection_test.go
@@ -86,7 +86,11 @@ data "ns_connection" "service" {
 			resource.TestCheckResourceAttr("data.ns_connection.service", `outputs.test3.key3`, "value3"),
 		)
 
-		os.Setenv("NULLSTONE_CONNECTION_service", "stack0-env0-lycan")
+		os.Setenv("NULLSTONE_ORG", "")
+		os.Setenv("NULLSTONE_STACK", "stack0")
+		os.Setenv("NULLSTONE_ENV", "env0")
+		os.Setenv("NULLSTONE_BLOCK", "faceless")
+		os.Setenv("NULLSTONE_CONNECTION_service", "lycan")
 
 		getTfeConfig, closeFn := mockTfe(mockServerWithLycan())
 		defer closeFn()

--- a/internal/provider/data_connection_test.go
+++ b/internal/provider/data_connection_test.go
@@ -86,7 +86,6 @@ data "ns_connection" "service" {
 			resource.TestCheckResourceAttr("data.ns_connection.service", `outputs.test3.key3`, "value3"),
 		)
 
-		os.Setenv("NULLSTONE_ORG", "")
 		os.Setenv("NULLSTONE_STACK", "stack0")
 		os.Setenv("NULLSTONE_ENV", "env0")
 		os.Setenv("NULLSTONE_BLOCK", "faceless")
@@ -136,7 +135,7 @@ func mockServerWithLycan() http.Handler {
       "name": "stack0-env0-lycan",
       "serial": 1,
       "lineage": "64aef234-2ff9-9d8e-25ae-22fb30b62860",
-      "hosted-state-download-url": "/state/terraform/v2/state-versions/53516a9e-ffd7-4834-8234-63fd070d064f/download"
+      "hosted-state-download-url": "/terraform/v2/state-versions/53516a9e-ffd7-4834-8234-63fd070d064f/download"
     },
     "relationships": {}
   }
@@ -183,7 +182,7 @@ func mockTfeStatePull(workspaces map[string]json.RawMessage, currentStateVersion
 	router := mux.NewRouter()
 	router.
 		Methods(http.MethodGet).
-		Path("/state/terraform/v2/organizations/{orgName}/workspaces/{workspaceName}").
+		Path("/terraform/v2/organizations/{orgName}/workspaces/{workspaceName}").
 		HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			vars := mux.Vars(r)
 			_, workspaceName := vars["orgName"], vars["workspaceName"]
@@ -195,7 +194,7 @@ func mockTfeStatePull(workspaces map[string]json.RawMessage, currentStateVersion
 		})
 	router.
 		Methods(http.MethodGet).
-		Path("/state/terraform/v2/workspaces/{workspaceId}/current-state-version").
+		Path("/terraform/v2/workspaces/{workspaceId}/current-state-version").
 		HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			workspaceId := mux.Vars(r)["workspaceId"]
 			if msg, ok := currentStateVersions[workspaceId]; ok {
@@ -206,7 +205,7 @@ func mockTfeStatePull(workspaces map[string]json.RawMessage, currentStateVersion
 		})
 	router.
 		Methods(http.MethodGet).
-		Path("/state/terraform/v2/state-versions/{stateVersionId}/download").
+		Path("/terraform/v2/state-versions/{stateVersionId}/download").
 		HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			stateVersionId := mux.Vars(r)["stateVersionId"]
 			if msg, ok := stateFiles[stateVersionId]; ok {

--- a/internal/provider/plan_config.go
+++ b/internal/provider/plan_config.go
@@ -17,15 +17,14 @@ type PlanConfig struct {
 }
 
 func (c PlanConfig) GetConnectionWorkspace(name string) string {
+	connValue := os.Getenv(fmt.Sprintf(`NULLSTONE_CONNECTION_%s`, name))
 	if value, ok := c.Connections[name]; ok {
-		return c.FullyQualifiedConnection(value)
-	} else {
-		value := os.Getenv(fmt.Sprintf(`NULLSTONE_CONNECTION_%s`, name))
-		if value == "" {
-			return ""
-		}
-		return c.FullyQualifiedConnection(value)
+		connValue = value
 	}
+	if connValue == "" {
+		return ""
+	}
+	return c.FullyQualifiedConnection(connValue)
 }
 
 func (c PlanConfig) FullyQualifiedConnection(name string) string {

--- a/internal/provider/plan_config.go
+++ b/internal/provider/plan_config.go
@@ -21,6 +21,9 @@ func (c PlanConfig) GetConnectionWorkspace(name string) string {
 		return c.FullyQualifiedConnection(value)
 	} else {
 		value := os.Getenv(fmt.Sprintf(`NULLSTONE_CONNECTION_%s`, name))
+		if value == "" {
+			return ""
+		}
 		return c.FullyQualifiedConnection(value)
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"log"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
@@ -90,6 +91,8 @@ func (p *provider) Configure(ctx context.Context, config map[string]tftypes.Valu
 	if err != nil {
 		return nil, err
 	}
+
+	log.Printf("[DEBUG] Configured TFE client (Address=%s, BasePath=%s)\n", p.TfeConfig.Address, p.TfeConfig.BasePath)
 
 	return nil, nil
 }

--- a/ns/tfe_config.go
+++ b/ns/tfe_config.go
@@ -13,6 +13,6 @@ func NewTfeConfig() *tfe.Config {
 	if cfg.Address == "" {
 		cfg.Address = DefaultAddress
 	}
-	cfg.BasePath = "/state/terraform/v2/"
+	cfg.BasePath = "/terraform/v2/"
 	return cfg
 }

--- a/ns/tfe_config.go
+++ b/ns/tfe_config.go
@@ -1,6 +1,8 @@
 package ns
 
 import (
+	"os"
+	
 	"github.com/hashicorp/go-tfe"
 )
 
@@ -10,8 +12,9 @@ var (
 
 func NewTfeConfig() *tfe.Config {
 	cfg := tfe.DefaultConfig()
-	if cfg.Address == "" {
-		cfg.Address = DefaultAddress
+	cfg.Address = DefaultAddress
+	if val := os.Getenv("TFE_ADDRESS"); val != "" {
+		cfg.Address = val
 	}
 	cfg.BasePath = "/terraform/v2/"
 	return cfg

--- a/website/docs/d/connection.html.markdown
+++ b/website/docs/d/connection.html.markdown
@@ -44,6 +44,12 @@ data "ns_connection" "network" {
 * `name` - Name of nullstone connection.
 * `type` - Type of nullstone module to make connection.
 * `optional` - By default, if this connection has not been configured, this causes an error. Set to true to disable. (Default: `false`)
-* `workspace` - Name of workspace for connection. (Environment variable: `NULLSTONE_CONNECTION_{name}`)
+* `workspace` - This refers to the exact workspace used for state files in nullstone.
+  This value will always be of the form `{stack}-{env}-{block}`.
+  Utilizes environment variable `NULLSTONE_CONNECTION_{name}` to resolve.
+  This value can be one of the following formats:
+    * `{stack}.{env}.{block}`
+    * `{env}.{block}`
+    * `{block}`
 * `via` - Name of workspace to satisfy this connection through. Typically, this is set to `data.ns_connection.other.workspace`.
 - `outputs` - An object containing every root-level output in the remote state. This attribute is interchangeable for `data.terraform_remote_state.outputs`.

--- a/website/docs/d/connection.html.markdown
+++ b/website/docs/d/connection.html.markdown
@@ -49,7 +49,7 @@ data "ns_connection" "network" {
   Utilizes environment variable `NULLSTONE_CONNECTION_{name}` to resolve.
   This value can be one of the following formats:
     * `{stack}.{env}.{block}`
-    * `{env}.{block}`
-    * `{block}`
+    * `{env}.{block}` - (`stack` is pulled from the current workspace)
+    * `{block}` - (`stack` and `env` are pulled from the current workspace)
 * `via` - Name of workspace to satisfy this connection through. Typically, this is set to `data.ns_connection.other.workspace`.
 - `outputs` - An object containing every root-level output in the remote state. This attribute is interchangeable for `data.terraform_remote_state.outputs`.


### PR DESCRIPTION
* Fixed interaction with nullstone servers based on changes to base path.
* Added graceful failures to read state file and outputs.
* Added logging that can be seen when using `TF_LOG=DEBUG`
* Appropriately resolving `ns_connection.workspace` based on `{stack}.{env}.{workspace}` regardless of the input value.
* Fixed default address for TFE client contacting nullstone.