### PR TITLE
C373 remove unused apis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,5 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.3.0
 	github.com/nullstone-io/module v0.2.3
 	github.com/stretchr/testify v1.5.1
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210520130828-f66258f36214
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210612172101-d5b816cc5368
 )

--- a/go.sum
+++ b/go.sum
@@ -574,6 +574,8 @@ gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qS
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210520130828-f66258f36214 h1:ascI8QO7QLUa2JJIQrnV4jAKeJjCKmp8OBz4EhpAOF8=
 gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210520130828-f66258f36214/go.mod h1:6z3xyBE0tWngWi5equdUPGtEKClza3g5hpSkQKWLid8=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210612172101-d5b816cc5368 h1:Ody22vsKXQBxYEweL9OAUhnGpnzkJucxv5wbfNKk2B8=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210612172101-d5b816cc5368/go.mod h1:6z3xyBE0tWngWi5equdUPGtEKClza3g5hpSkQKWLid8=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/provider/data_app_env_test.go
+++ b/internal/provider/data_app_env_test.go
@@ -244,7 +244,7 @@ func mockNsHandlerAppEnvs(appEnvs *[]*types.AppEnv, apps []*types.Application, e
 		})
 	router.
 		Methods(http.MethodGet).
-		Path("/orgs/{orgName}/stacks_by_id/{stackId}/envs/{envId}").
+		Path("/orgs/{orgName}/stacks/{stackId}/envs/{envId}").
 		HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			vars := mux.Vars(r)
 			if env := findEnv(vars["orgName"], vars["stackId"], vars["envId"]); env == nil {


### PR DESCRIPTION
This PR updates this repo to use the latest go-api-client (which had a bunch of endpoints removed).