### PR TITLE
C369/autogen env

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,5 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.3.0
 	github.com/nullstone-io/module v0.2.3
 	github.com/stretchr/testify v1.5.1
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210612172101-d5b816cc5368
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210616013145-0d722f8335a6
 )

--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,5 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.3.0
 	github.com/nullstone-io/module v0.2.3
 	github.com/stretchr/testify v1.5.1
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210616013145-0d722f8335a6
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210621143140-078af9772ae4
 )

--- a/go.sum
+++ b/go.sum
@@ -572,12 +572,8 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8X
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210520130828-f66258f36214 h1:ascI8QO7QLUa2JJIQrnV4jAKeJjCKmp8OBz4EhpAOF8=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210520130828-f66258f36214/go.mod h1:6z3xyBE0tWngWi5equdUPGtEKClza3g5hpSkQKWLid8=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210612172101-d5b816cc5368 h1:Ody22vsKXQBxYEweL9OAUhnGpnzkJucxv5wbfNKk2B8=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210612172101-d5b816cc5368/go.mod h1:6z3xyBE0tWngWi5equdUPGtEKClza3g5hpSkQKWLid8=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210616013145-0d722f8335a6 h1:4H0Zaxb/d8tngEHr09Ywx7NR0nzqcZbQAdxuFfMY6ss=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210616013145-0d722f8335a6/go.mod h1:6z3xyBE0tWngWi5equdUPGtEKClza3g5hpSkQKWLid8=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210621143140-078af9772ae4 h1:SlpFzbjuRVBOO23DYvZiBO83Ms2n/Akhajh+yZJX1Qk=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210621143140-078af9772ae4/go.mod h1:6z3xyBE0tWngWi5equdUPGtEKClza3g5hpSkQKWLid8=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -576,6 +576,8 @@ gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210520130828-f66258f36214 h1:asc
 gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210520130828-f66258f36214/go.mod h1:6z3xyBE0tWngWi5equdUPGtEKClza3g5hpSkQKWLid8=
 gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210612172101-d5b816cc5368 h1:Ody22vsKXQBxYEweL9OAUhnGpnzkJucxv5wbfNKk2B8=
 gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210612172101-d5b816cc5368/go.mod h1:6z3xyBE0tWngWi5equdUPGtEKClza3g5hpSkQKWLid8=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210616013145-0d722f8335a6 h1:4H0Zaxb/d8tngEHr09Ywx7NR0nzqcZbQAdxuFfMY6ss=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210616013145-0d722f8335a6/go.mod h1:6z3xyBE0tWngWi5equdUPGtEKClza3g5hpSkQKWLid8=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/provider/autogen_subdomain_test.go
+++ b/internal/provider/autogen_subdomain_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func mockNsServerWithAutogenSubdomains(autogenSubdomains map[string]map[string]map[string]*types.AutogenSubdomain) http.Handler {
-	findAutogenSubdomain := func(orgName string, subdomainId string, envName string) *types.AutogenSubdomain {
+	findAutogenSubdomain := func(orgName string, subdomainId string, envId string) *types.AutogenSubdomain {
 		orgScoped, ok := autogenSubdomains[orgName]
 		if !ok {
 			return nil
@@ -18,7 +18,7 @@ func mockNsServerWithAutogenSubdomains(autogenSubdomains map[string]map[string]m
 		if !ok {
 			return nil
 		}
-		result, ok := subdomainScoped[envName]
+		result, ok := subdomainScoped[envId]
 		if !ok {
 			return nil
 		}
@@ -28,7 +28,7 @@ func mockNsServerWithAutogenSubdomains(autogenSubdomains map[string]map[string]m
 	router := mux.NewRouter()
 	router.
 		Methods(http.MethodPost).
-		Path("/orgs/{orgName}/subdomains/{subdomainId}/envs/{envName}/autogen_subdomain").
+		Path("/orgs/{orgName}/subdomains/{subdomainId}/envs/{envId}/autogen_subdomain").
 		HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			orgName := mux.Vars(r)["orgName"]
 			// NOTE: We're going to always return the same one we created instead of being random
@@ -45,17 +45,17 @@ func mockNsServerWithAutogenSubdomains(autogenSubdomains map[string]map[string]m
 		})
 	router.
 		Methods(http.MethodDelete).
-		Path("/orgs/{orgName}/subdomains/{subdomainId}/envs/{envName}/autogen_subdomain").
+		Path("/orgs/{orgName}/subdomains/{subdomainId}/envs/{envId}/autogen_subdomain").
 		HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNoContent)
 		})
 	router.
 		Methods(http.MethodGet).
-		Path("/orgs/{orgName}/subdomains/{subdomainId}/envs/{envName}/autogen_subdomain").
+		Path("/orgs/{orgName}/subdomains/{subdomainId}/envs/{envId}/autogen_subdomain").
 		HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			vars := mux.Vars(r)
-			orgName, subdomainId, env := vars["orgName"], vars["subdomainId"], vars["envName"]
-			autogenSubdomain := findAutogenSubdomain(orgName, subdomainId, env)
+			orgName, subdomainId, envId := vars["orgName"], vars["subdomainId"], vars["envId"]
+			autogenSubdomain := findAutogenSubdomain(orgName, subdomainId, envId)
 			if autogenSubdomain != nil {
 				raw, _ := json.Marshal(autogenSubdomain)
 				w.Write(raw)
@@ -65,12 +65,12 @@ func mockNsServerWithAutogenSubdomains(autogenSubdomains map[string]map[string]m
 		})
 	router.
 		Methods(http.MethodPut).
-		Path("/orgs/{orgName}/subdomains/{subdomainId}/envs/{envName}/autogen_subdomain/delegation").
+		Path("/orgs/{orgName}/subdomains/{subdomainId}/envs/{envId}/autogen_subdomain/delegation").
 		Headers("Content-Type", "application/json").
 		HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			vars := mux.Vars(r)
-			orgName, subdomainId, env := vars["orgName"], vars["subdomainId"], vars["envName"]
-			autogenSubdomain := findAutogenSubdomain(orgName, subdomainId, env)
+			orgName, subdomainId, envId := vars["orgName"], vars["subdomainId"], vars["envId"]
+			autogenSubdomain := findAutogenSubdomain(orgName, subdomainId, envId)
 			if autogenSubdomain == nil {
 				http.NotFound(w, r)
 				return
@@ -94,11 +94,11 @@ func mockNsServerWithAutogenSubdomains(autogenSubdomains map[string]map[string]m
 		})
 	router.
 		Methods(http.MethodDelete).
-		Path("/orgs/{orgName}/subdomains/{subdomainId}/envs/{envName}/autogen_subdomain/delegation").
+		Path("/orgs/{orgName}/subdomains/{subdomainId}/envs/{envId}/autogen_subdomain/delegation").
 		HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			vars := mux.Vars(r)
-			orgName, subdomainId, env := vars["orgName"], vars["subdomainId"], vars["envName"]
-			if autogenSubdomain := findAutogenSubdomain(orgName, subdomainId, env); autogenSubdomain == nil {
+			orgName, subdomainId, envId := vars["orgName"], vars["subdomainId"], vars["envId"]
+			if autogenSubdomain := findAutogenSubdomain(orgName, subdomainId, envId); autogenSubdomain == nil {
 				http.NotFound(w, r)
 				return
 			}

--- a/internal/provider/resource_autogen_subdomain_delegation_test.go
+++ b/internal/provider/resource_autogen_subdomain_delegation_test.go
@@ -12,7 +12,7 @@ func TestResourceSubdomainDelegation(t *testing.T) {
 	autogenSubdomains := map[string]map[string]map[string]*types.AutogenSubdomain{
 		"org0": {
 			"1": {
-				"prod": {
+				"15": {
 					IdModel:     types.IdModel{Id: 1},
 					DnsName:     "api",
 					DomainName:  "nullstone.app",
@@ -21,7 +21,7 @@ func TestResourceSubdomainDelegation(t *testing.T) {
 				},
 			},
 			"2": {
-				"prod": {
+				"15": {
 					IdModel:     types.IdModel{Id: 2},
 					DnsName:     "docs",
 					DomainName:  "nullstone.app",
@@ -39,7 +39,7 @@ provider "ns" {
 }
 resource "ns_autogen_subdomain_delegation" "to_fake" {
   subdomain_id = 99
-  env 		   = "prod"
+  env_id       = 15
   nameservers  = ["1.1.1.1","2.2.2.2","3.3.3.3"]
 }
 `)
@@ -55,7 +55,7 @@ resource "ns_autogen_subdomain_delegation" "to_fake" {
 				{
 					Config:      tfconfig,
 					Check:       checks,
-					ExpectError: regexp.MustCompile(`The autogen_subdomain_delegation for the subdomain 99 and env "prod" is missing.`),
+					ExpectError: regexp.MustCompile(`The autogen_subdomain_delegation for the subdomain 99 and env 15 is missing.`),
 				},
 			},
 		})
@@ -68,7 +68,7 @@ provider "ns" {
 }
 resource "ns_autogen_subdomain_delegation" "to_fake" {
   subdomain_id	= 1
-  env 			= "prod"
+  env_id        = 15
   nameservers 	= ["1.1.1.1","2.2.2.2","3.3.3.3"]
 }
 `)
@@ -101,7 +101,7 @@ provider "ns" {
 }
 resource "ns_autogen_subdomain_delegation" "to_fake" {
   subdomain_id 	= 2
-  env 			= "prod"
+  env_id        = 15
   nameservers 	= ["5.5.5.5", "6.6.6.6", "7.7.7.7"]
 }
 `)

--- a/internal/provider/resource_autogen_subdomain_test.go
+++ b/internal/provider/resource_autogen_subdomain_test.go
@@ -19,7 +19,7 @@ provider "ns" {
 }
 resource "ns_autogen_subdomain" "autogen_subdomain" {
   subdomain_id 	= 99
-  env 			= "prod"
+  env_id        = 15
 }
 `)
 

--- a/website/docs/r/autogen_subdomain.markdown
+++ b/website/docs/r/autogen_subdomain.markdown
@@ -20,7 +20,7 @@ data "ns_workspace" "this" {}
 
 resource "ns_autogen_subdomain" "autogen_subdomain" {
   subdomain_id = data.ns_workspace.this.block_id
-  env          = data.ns_workspace.this.env_name
+  env_id       = data.ns_workspace.this.env_id
 }
 
 resource "aws_route53_zone" "this" {
@@ -30,7 +30,7 @@ resource "aws_route53_zone" "this" {
 
 resource "ns_autogen_subdomain_delegation" "to_aws" {
   subdomain_id = data.ns_workspace.this.block_id
-  env          = data.ns_workspace.this.env_name
+  env_id       = data.ns_workspace.this.env_id
   nameservers  = aws_route53_zone.this.name_servers
 }
 ```

--- a/website/docs/r/autogen_subdomain_delegation.markdown
+++ b/website/docs/r/autogen_subdomain_delegation.markdown
@@ -20,7 +20,7 @@ data "ns_workspace" "this" {}
 
 resource "ns_autogen_subdomain" "autogen_subdomain" {
   subdomain_id = data.ns_workspace.this.block_id
-  env          = data.ns_workspace.this.env_name
+  env_id       = data.ns_workspace.this.env_id
 }
 
 resource "aws_route53_zone" "this" {
@@ -30,7 +30,7 @@ resource "aws_route53_zone" "this" {
 
 resource "ns_autogen_subdomain_delegation" "to_aws" {
   subdomain_id = data.ns_workspace.this.block_id
-  env          = data.ns_workspace.this.env_name
+  env_id       = data.ns_workspace.this.env_id
   nameservers  = aws_route53_zone.this.name_servers
 }
 ```
@@ -39,7 +39,7 @@ resource "ns_autogen_subdomain_delegation" "to_aws" {
 
 - `subdomain_id` - (Required) Id of the subdomain that already exists in Nullstone system.
   The subdomain in Nullstone represents the block. This represents the subdomain name created for each environment.
-- `env` - (Required) Name of the environment to create an autogen_subdomain in.
+- `env_id` - (Required) ID of the environment to create an autogen_subdomain in.
 - `nameservers` - (Required) A list of nameservers that refer to a DNS zone where this subdomain can delegate.
 
 ## Attributes Reference


### PR DESCRIPTION
https://app.ora.pm/p/76fc4569fe5049a6b91710fae25e141b?v=48413&s=18798&t=k&c=f14408a3e5654618a8daeb89f6f66035
This PR allows users to rename environment name without affecting the autogen subdomain.

This PR reindexes autogen subdomains to env id instead of env name.

Dependent on:
- https://github.com/nullstone-io/go-api-client/pull/14