### PR TITLE
C421/capabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,3 +14,5 @@ require (
 	github.com/stretchr/testify v1.5.1
 	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210621143140-078af9772ae4
 )
+
+replace gopkg.in/nullstone-io/go-api-client.v0 latest => gopkg.in/nullstone-io/go-api-client.v0 branch

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,5 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.3.0
 	github.com/nullstone-io/module v0.2.3
 	github.com/stretchr/testify v1.5.1
-	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210621143140-078af9772ae4
+	gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210710145057-9a21d09b9a28
 )
-
-replace gopkg.in/nullstone-io/go-api-client.v0 latest => gopkg.in/nullstone-io/go-api-client.v0 branch

--- a/go.sum
+++ b/go.sum
@@ -574,6 +574,8 @@ gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qS
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210621143140-078af9772ae4 h1:SlpFzbjuRVBOO23DYvZiBO83Ms2n/Akhajh+yZJX1Qk=
 gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210621143140-078af9772ae4/go.mod h1:6z3xyBE0tWngWi5equdUPGtEKClza3g5hpSkQKWLid8=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210709125331-2a1452950f27 h1:7446mQatMhO+q7N3Y1CoJKzmYiNO3VjiU0OfcILJV6M=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210709125331-2a1452950f27/go.mod h1:6z3xyBE0tWngWi5equdUPGtEKClza3g5hpSkQKWLid8=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -572,10 +572,8 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8X
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210621143140-078af9772ae4 h1:SlpFzbjuRVBOO23DYvZiBO83Ms2n/Akhajh+yZJX1Qk=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210621143140-078af9772ae4/go.mod h1:6z3xyBE0tWngWi5equdUPGtEKClza3g5hpSkQKWLid8=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210709125331-2a1452950f27 h1:7446mQatMhO+q7N3Y1CoJKzmYiNO3VjiU0OfcILJV6M=
-gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210709125331-2a1452950f27/go.mod h1:6z3xyBE0tWngWi5equdUPGtEKClza3g5hpSkQKWLid8=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210710145057-9a21d09b9a28 h1:jdhvKABzIOJzTLFHSe6oNUaSJL+F0lGTpZURISwNhO8=
+gopkg.in/nullstone-io/go-api-client.v0 v0.0.0-20210710145057-9a21d09b9a28/go.mod h1:6z3xyBE0tWngWi5equdUPGtEKClza3g5hpSkQKWLid8=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/provider/data_connection.go
+++ b/internal/provider/data_connection.go
@@ -164,16 +164,27 @@ func (d *dataConnection) Read(ctx context.Context, config map[string]tftypes.Val
 func (d *dataConnection) getConnectionWorkspace(name, type_, via string) (*types.WorkspaceTarget, error) {
 	sourceWorkspace := d.p.PlanConfig.WorkspaceTarget()
 
-	log.Printf("(getConnectionWorkspace) Pulling connections for @ %s", sourceWorkspace.Id())
+	log.Printf("(getConnectionWorkspace) Pulling workspace run config for @ %s", sourceWorkspace.Id())
 	runConfig, err := ns.GetWorkspaceConfig(d.p.NsConfig, sourceWorkspace)
 	if err != nil {
 		return nil, err
 	}
 
+	connections := runConfig.Connections
+	capabilityId := d.p.PlanConfig.CapabilityId
+	if capabilityId > 0 {
+		for _, cap := range runConfig.Capabilities {
+			if cap.Id == capabilityId {
+				connections = cap.Connections
+				break
+			}
+		}
+	}
+
 	// If this data_connection has `via` specified, then we need to
 	//   get the connections for *that* workspace instead of the current workspace
 	if via != "" {
-		viaWorkspaceConn, ok := runConfig.Connections[via]
+		viaWorkspaceConn, ok := connections[via]
 		if !ok || viaWorkspaceConn.Reference == nil {
 			log.Printf("via connection (%s) was not found in %s", via, sourceWorkspace.Id())
 			return nil, nil
@@ -188,7 +199,7 @@ func (d *dataConnection) getConnectionWorkspace(name, type_, via string) (*types
 		runConfig = viaRunConfig
 	}
 
-	conn, ok := runConfig.Connections[name]
+	conn, ok := connections[name]
 	if !ok || conn.Reference == nil {
 		log.Printf("connection (%s) was not found in %s", name, sourceWorkspace.Id())
 		return nil, nil

--- a/internal/provider/data_connection.go
+++ b/internal/provider/data_connection.go
@@ -197,6 +197,7 @@ func (d *dataConnection) getConnectionWorkspace(name, type_, via string) (*types
 		}
 		sourceWorkspace = viaWorkspace
 		runConfig = viaRunConfig
+		connections = runConfig.Connections
 	}
 
 	conn, ok := connections[name]

--- a/internal/provider/data_connection_test.go
+++ b/internal/provider/data_connection_test.go
@@ -65,7 +65,7 @@ func TestDataConnection(t *testing.T) {
 						Optional: false,
 					},
 					Target: "lycan",
-					Reference: &types.BlockConnection{
+					Reference: &types.ConnectionTarget{
 						StackId: lycanEnv0.StackId,
 						BlockId: lycanEnv0.BlockId,
 					},
@@ -82,7 +82,7 @@ func TestDataConnection(t *testing.T) {
 						Optional: false,
 					},
 					Target: "rikimaru",
-					Reference: &types.BlockConnection{
+					Reference: &types.ConnectionTarget{
 						StackId: rikiEnv0.StackId,
 						BlockId: rikiEnv0.BlockId,
 					},

--- a/internal/provider/plan_config.go
+++ b/internal/provider/plan_config.go
@@ -21,7 +21,7 @@ type PlanConfig struct {
 	EnvId   int64  `json:"envId"`
 	EnvName string `json:"envName"`
 
-	CapabilityId string `json:"capabilityId"`
+	CapabilityId int64 `json:"capabilityId"`
 }
 
 func (c PlanConfig) WorkspaceTarget() types.WorkspaceTarget {

--- a/internal/provider/plan_config.go
+++ b/internal/provider/plan_config.go
@@ -20,6 +20,8 @@ type PlanConfig struct {
 
 	EnvId   int64  `json:"envId"`
 	EnvName string `json:"envName"`
+
+	CapabilityId string `json:"capabilityId"`
 }
 
 func (c PlanConfig) WorkspaceTarget() types.WorkspaceTarget {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -65,6 +65,13 @@ func (p *provider) Schema(ctx context.Context) *tfprotov5.Schema {
 					Description:     "Configure provider with this organization.",
 					DescriptionKind: tfprotov5.StringKindMarkdown,
 				},
+				{
+					Name:            "capability_id",
+					Type:            tftypes.Number,
+					Optional:        true,
+					Description:     "Configure provider with the context of the capability's id",
+					DescriptionKind: tfprotov5.StringKindMarkdown,
+				},
 			},
 		},
 	}
@@ -108,6 +115,10 @@ func (p *provider) Configure(ctx context.Context, config map[string]tftypes.Valu
 
 	p.NsConfig.OrgName = p.PlanConfig.OrgName
 	log.Printf("[DEBUG] Configured Nullstone API client (Address=%s)\n", p.NsConfig.BaseAddress)
+
+	if !config["capability_id"].IsNull() {
+		config["capability_id"].As(&p.PlanConfig.CapabilityId)
+	}
 
 	p.TfeClient, err = tfe.NewClient(p.TfeConfig)
 	if err != nil {

--- a/website/docs/d/connection.html.markdown
+++ b/website/docs/d/connection.html.markdown
@@ -12,7 +12,9 @@ Data source to configure connection to another nullstone workspace.
 This stanza defines the name and type of connection we need.
 During terraform execution, nullstone provides outputs from the connected workspace.
 
-This data source is affected by Plan Config. See [the main provider documentation](../index.html) for more details.
+Plan Config affects this data source. See [the main provider documentation](../index.html) for more details.
+Specific to this data source, if the provider specifies `capability_id`, 
+this data source will pull connections from the capability rather than the owning application.
 
 ## Example Usage
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -14,7 +14,7 @@ Use the navigation to the left to read about the available resources.
 
 ## Example Usage
 
-```hcl
+```terraform
 provider "ns" {
 }
 
@@ -43,7 +43,7 @@ Set `NULSTONE_API_KEY` to your nullstone API key.
 
 When running inside a Nullstone runner, Nullstone will automatically configure the plan configuration all resources in this provider.
 However, if you want to run locally, you may configure the current organization and workspace through a plan config.
-This plan config is loaded by environment variables or from `.nullstone.json`.
+This terraform provider loads the plan config by environment variables or from `.nullstone.json`.
 
 The following is an example `.nullstone.json`.
 ```json
@@ -69,4 +69,24 @@ NULLSTONE_BLOCK_NAME=core
 NULLSTONE_BLOCK_REF=yellow-giraffe
 NULLSTONE_ENV_ID=102
 NULLSTONE_ENV_NAME=prod
+```
+
+## Capabilities
+
+When constructing app modules that use capabilities, you can use an aliased provider to scope the module.
+This ensures that connections defined within the module pull connection configuration from the capability rather than the application.
+
+```terraform
+provider "ns" {
+  capability_id = 5
+  alias         = "cap_5"
+}
+
+module "cap_5" {
+  source = "nullstone/capability"
+  
+  providers = {
+    ns = ns.cap_5
+  }
+}
 ```


### PR DESCRIPTION
This PR updates `data.ns_connection` to work within a capability.
Before this PR, a connection inside a capability would use the owning application's store of connections.
Additionally, this ensures that `data.ns_workspace` works properly when using `.nullstone.json` instead of env vars.

Relies on https://github.com/nullstone-io/go-api-client/pull/15