### PR TITLE
Gracefully fail if nullstone fails to create/update resources

### DIFF
--- a/internal/provider/resource_autogen_subdomain.go
+++ b/internal/provider/resource_autogen_subdomain.go
@@ -139,6 +139,11 @@ func (r *resourceAutogenSubdomain) Create(ctx context.Context, planned map[strin
 	subdomainId := extractInt64FromConfig(config, "subdomain_id")
 	envId := extractInt64FromConfig(config, "env_id")
 
+	var id int64
+	var dnsName string
+	var domainName string
+	var fqdn string
+
 	nsClient := &api.Client{Config: r.p.NsConfig}
 	if autogenSubdomain, err := nsClient.AutogenSubdomain().Create(subdomainId, envId); err != nil {
 		diags = append(diags, &tfprotov5.Diagnostic{
@@ -159,13 +164,18 @@ func (r *resourceAutogenSubdomain) Create(ctx context.Context, planned map[strin
 			diag.Detail = fmt.Sprintf("unknown cause")
 		}
 	} else {
-		state["id"] = tftypes.NewValue(tftypes.String, fmt.Sprintf("%d", autogenSubdomain.Id))
-		state["subdomain_id"] = tftypes.NewValue(tftypes.Number, &subdomainId)
-		state["env_id"] = tftypes.NewValue(tftypes.Number, &envId)
-		state["dns_name"] = tftypes.NewValue(tftypes.String, autogenSubdomain.DnsName)
-		state["domain_name"] = tftypes.NewValue(tftypes.String, autogenSubdomain.DomainName)
-		state["fqdn"] = tftypes.NewValue(tftypes.String, autogenSubdomain.Fqdn)
+		id = autogenSubdomain.Id
+		dnsName = autogenSubdomain.DnsName
+		domainName = autogenSubdomain.DomainName
+		fqdn = autogenSubdomain.Fqdn
 	}
+
+	state["id"] = tftypes.NewValue(tftypes.String, fmt.Sprintf("%d", id))
+	state["subdomain_id"] = tftypes.NewValue(tftypes.Number, &subdomainId)
+	state["env_id"] = tftypes.NewValue(tftypes.Number, &envId)
+	state["dns_name"] = tftypes.NewValue(tftypes.String, dnsName)
+	state["domain_name"] = tftypes.NewValue(tftypes.String, domainName)
+	state["fqdn"] = tftypes.NewValue(tftypes.String, fqdn)
 
 	return state, diags, nil
 }

--- a/internal/provider/resource_autogen_subdomain_delegation.go
+++ b/internal/provider/resource_autogen_subdomain_delegation.go
@@ -126,6 +126,8 @@ func (r *resourceAutogenSubdomainDelegation) Update(ctx context.Context, planned
 	nameservers, _ := extractStringSliceFromConfig(planned, "nameservers")
 	autogenSubdomain := &types.AutogenSubdomain{Nameservers: nameservers}
 
+	var id int64
+
 	nsClient := &api.Client{Config: r.p.NsConfig}
 	if result, err := nsClient.AutogenSubdomainDelegation().Update(subdomainId, envId, autogenSubdomain); err != nil {
 		diags = append(diags, &tfprotov5.Diagnostic{
@@ -139,11 +141,14 @@ func (r *resourceAutogenSubdomainDelegation) Update(ctx context.Context, planned
 			Summary:  fmt.Sprintf("The autogen_subdomain_delegation for the subdomain %d and env %d is missing.", subdomainId, envId),
 		})
 	} else {
-		state["id"] = tftypes.NewValue(tftypes.String, fmt.Sprintf("%d", autogenSubdomain.Id))
-		state["subdomain_id"] = tftypes.NewValue(tftypes.Number, &subdomainId)
-		state["env_id"] = tftypes.NewValue(tftypes.Number, &envId)
-		state["nameservers"] = ns.NameserversToProtov5(autogenSubdomain.Nameservers)
+		id = autogenSubdomain.Id
+		nameservers = autogenSubdomain.Nameservers
 	}
+
+	state["id"] = tftypes.NewValue(tftypes.String, fmt.Sprintf("%d", id))
+	state["subdomain_id"] = tftypes.NewValue(tftypes.Number, &subdomainId)
+	state["env_id"] = tftypes.NewValue(tftypes.Number, &envId)
+	state["nameservers"] = ns.NameserversToProtov5(nameservers)
 
 	return state, diags, nil
 }


### PR DESCRIPTION
In the case where furion failed to create an autogen subdomain or update autogen subdomain delegation, this provider would leave the resource schema unset.
This PR changes the 2 terraform resources to always set *all* schema attributes.