### PR TITLE
fix rbac endpoint

### DIFF
--- a/internal/provider/data_subdomain.go
+++ b/internal/provider/data_subdomain.go
@@ -69,7 +69,7 @@ func (d *dataSubdomain) Read(ctx context.Context, config map[string]tftypes.Valu
 	var subdomainId int64
 	var dnsName string
 
-	subdomain, err := nsClient.Subdomains().Get(stackId, blockId)
+	subdomain, err := nsClient.Subdomains().GlobalGet(blockId)
 	if err != nil {
 		diags = append(diags, &tfprotov5.Diagnostic{
 			Severity: tfprotov5.DiagnosticSeverityError,

--- a/internal/provider/subdomain_test.go
+++ b/internal/provider/subdomain_test.go
@@ -11,7 +11,7 @@ func mockNsServerWithSubdomains() http.Handler {
 	router := mux.NewRouter()
 	router.
 		Methods(http.MethodGet).
-		Path("/orgs/{orgName}/stacks/{stackId}/subdomains/{subdomainId}").
+		Path("/orgs/{orgName}/subdomains/{subdomainId}").
 		HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			subdomain := types.Subdomain{
 				DnsName: "api",


### PR DESCRIPTION
This PR makes sure that the provider calls the correct endpoint. We ended up not converting the subdomains#get endpoint to live under /stacks/:stack_id because resource_autogen_subdomain couldn't provide a stackId. I need to remove this endpoint out of go-api-client so we don't have this confusion but this will fix the error for now.