### PR TITLE
F1266 env var interpolation

### DIFF
--- a/internal/provider/config_utils.go
+++ b/internal/provider/config_utils.go
@@ -5,6 +5,15 @@ import (
 	"math/big"
 )
 
+func extractStringFromTfValue(tfvalue tftypes.Value) string {
+	if tfvalue.IsNull() {
+		return ""
+	}
+	val := ""
+	tfvalue.As(&val)
+	return val
+}
+
 func extractStringFromConfig(config map[string]tftypes.Value, key string) string {
 	if config[key].IsNull() {
 		return ""
@@ -62,4 +71,23 @@ func extractStringSliceFromConfig(config map[string]tftypes.Value, key string) (
 		slice = append(slice, item)
 	}
 	return slice, nil
+}
+
+func extractMapFromConfig(config map[string]tftypes.Value, key string) map[string]tftypes.Value {
+	if config[key].IsNull() {
+		return make(map[string]tftypes.Value)
+	}
+	val := make(map[string]tftypes.Value)
+	if err := config[key].As(&val); err != nil {
+		return make(map[string]tftypes.Value)
+	}
+	return val
+}
+
+func copyMap(m map[string]tftypes.Value) map[string]tftypes.Value {
+	copy := make(map[string]tftypes.Value)
+	for k, v := range m {
+		copy[k] = v
+	}
+	return copy
 }

--- a/internal/provider/config_utils.go
+++ b/internal/provider/config_utils.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"math/big"
+	"regexp"
 )
 
 func extractStringFromTfValue(tfvalue tftypes.Value) string {
@@ -90,4 +91,11 @@ func copyMap(m map[string]tftypes.Value) map[string]tftypes.Value {
 		copy[k] = v
 	}
 	return copy
+}
+
+const envVariableKeyRegex = "^[a-zA-Z_][a-zA-Z0-9_]*$"
+
+func validEnvVariableKey(key string) bool {
+	regex := regexp.MustCompile(envVariableKeyRegex)
+	return regex.MatchString(key)
 }

--- a/internal/provider/data_variables.go
+++ b/internal/provider/data_variables.go
@@ -1,0 +1,184 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"hash/fnv"
+	"regexp"
+)
+
+type dataVariables struct {
+	p *provider
+}
+
+func newDataVariables(p *provider) (*dataVariables, error) {
+	if p == nil {
+		return nil, fmt.Errorf("a provider is required")
+	}
+	return &dataVariables{p: p}, nil
+}
+
+func (*dataVariables) Schema(ctx context.Context) *tfprotov5.Schema {
+	attrs := []*tfprotov5.SchemaAttribute{
+		deprecatedIDAttribute(),
+		{
+			Name:            "input_env_variables",
+			Type:            tftypes.Map{ElementType: tftypes.String},
+			Description:     "The raw environment variables before they are interpolated.",
+			DescriptionKind: tfprotov5.StringKindMarkdown,
+			Required:        true,
+		},
+		{
+			Name:            "input_secrets",
+			Type:            tftypes.Map{ElementType: tftypes.String},
+			Description:     "The raw secrets before they are interpolated.",
+			DescriptionKind: tfprotov5.StringKindMarkdown,
+			Required:        true,
+			Sensitive:       true,
+		},
+		{
+			Name:            "env_variable_keys",
+			Type:            tftypes.List{ElementType: tftypes.String},
+			Description:     "The keys of all the environment variables.",
+			DescriptionKind: tfprotov5.StringKindMarkdown,
+			Computed:        true,
+		},
+		{
+			Name:            "env_variables",
+			Type:            tftypes.Map{ElementType: tftypes.String},
+			Description:     "The processed environment variables after they are interpolated.",
+			DescriptionKind: tfprotov5.StringKindMarkdown,
+			Computed:        true,
+		},
+		{
+			Name:            "secret_keys",
+			Type:            tftypes.List{ElementType: tftypes.String},
+			Description:     "The keys of all the secrets.",
+			DescriptionKind: tfprotov5.StringKindMarkdown,
+			Computed:        true,
+		},
+		{
+			Name:            "secrets",
+			Type:            tftypes.Map{ElementType: tftypes.String},
+			Description:     "The processed secrets after they are interpolated.",
+			DescriptionKind: tfprotov5.StringKindMarkdown,
+			Computed:        true,
+			Sensitive:       true,
+		},
+	}
+
+	return &tfprotov5.Schema{
+		Version: 1,
+		Block: &tfprotov5.SchemaBlock{
+			Description:     "Data source to interpolate any variables or env variables into their final values.",
+			DescriptionKind: tfprotov5.StringKindMarkdown,
+			Attributes:      attrs,
+		},
+	}
+}
+
+func (d *dataVariables) Validate(ctx context.Context, config map[string]tftypes.Value) ([]*tfprotov5.Diagnostic, error) {
+	return nil, nil
+}
+
+func (d *dataVariables) Read(ctx context.Context, config map[string]tftypes.Value) (map[string]tftypes.Value, []*tfprotov5.Diagnostic, error) {
+	inputEnvVariables := extractMapFromConfig(config, "input_env_variables")
+	inputSecrets := extractMapFromConfig(config, "input_secrets")
+
+	// make sure we copy these so our changes below don't affect the original values
+	envVariables := copyMap(inputEnvVariables)
+	secrets := copyMap(inputSecrets)
+
+	regexPattern := "{{\\s?%s\\s?}}"
+
+	// we are going to first loop through all the input secrets
+	//   find and replace this secret in all the rest of the env variables and secrets
+	for key, secret := range secrets {
+		regex := regexp.MustCompile(fmt.Sprintf(regexPattern, key))
+		// first try and replace in the env variables
+		for k, v := range envVariables {
+			result := regex.ReplaceAllString(extractStringFromTfValue(v), extractStringFromTfValue(secret))
+			// if a match was found and replaced, this env variable is now a secret
+			if result != extractStringFromTfValue(v) {
+				delete(envVariables, k)
+				secrets[k] = tftypes.NewValue(tftypes.String, result)
+			}
+		}
+		// now do any replacements in the other secrets
+		for k, v := range secrets {
+			// we don't want to replace the secret with itself (this will prevent an infinite loop)
+			if k != key {
+				result := regex.ReplaceAllString(extractStringFromTfValue(v), extractStringFromTfValue(secret))
+				secrets[k] = tftypes.NewValue(tftypes.String, result)
+			}
+		}
+	}
+
+	// now we will loop through all the env variables
+	//   find and replace this env variable in all the rest of the env variables and secrets
+	for key, value := range envVariables {
+		regex := regexp.MustCompile(fmt.Sprintf(regexPattern, key))
+		for k, v := range envVariables {
+			// we don't want to replace the env variable with itself (this will prevent an infinite loop)
+			if k != key {
+				result := regex.ReplaceAllString(extractStringFromTfValue(v), extractStringFromTfValue(value))
+				envVariables[k] = tftypes.NewValue(tftypes.String, result)
+			}
+		}
+		for k, v := range secrets {
+			result := regex.ReplaceAllString(extractStringFromTfValue(v), extractStringFromTfValue(value))
+			secrets[k] = tftypes.NewValue(tftypes.String, result)
+		}
+	}
+
+	// extract the keys from the maps
+	envVariableKeys := make([]tftypes.Value, 0, len(envVariables))
+	for k, _ := range envVariables {
+		envVariableKeys = append(envVariableKeys, tftypes.NewValue(tftypes.String, k))
+	}
+	secretKeys := make([]tftypes.Value, 0, len(secrets))
+	for k, _ := range secrets {
+		secretKeys = append(secretKeys, tftypes.NewValue(tftypes.String, k))
+	}
+
+	// calculate the unique id for this data source based on a hash of the resulting env variables and secrets
+	id, err := d.HashFromValues(envVariables, secrets)
+	if err != nil {
+		diagnostic := &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Error generating a unique id for the data source",
+			Detail:   fmt.Sprintf("%s", err),
+		}
+		return nil, []*tfprotov5.Diagnostic{diagnostic}, fmt.Errorf("error generating a unique id for the data source: %w", err)
+	}
+
+	return map[string]tftypes.Value{
+		"id":                  tftypes.NewValue(tftypes.String, *id),
+		"input_env_variables": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, inputEnvVariables),
+		"input_secrets":       tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, inputSecrets),
+		"env_variable_keys":   tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, envVariableKeys),
+		"env_variables":       tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, envVariables),
+		"secret_keys":         tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, secretKeys),
+		"secrets":             tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, secrets),
+	}, nil, nil
+}
+
+func (d *dataVariables) HashFromValues(envVariables, secrets map[string]tftypes.Value) (*string, error) {
+	hashString := ""
+	for k, v := range envVariables {
+		hashString += fmt.Sprintf("%s=%s;", k, extractStringFromTfValue(v))
+	}
+	for k, v := range secrets {
+		hashString += fmt.Sprintf("%s=%s;", k, extractStringFromTfValue(v))
+	}
+
+	h := fnv.New32a()
+	_, err := h.Write([]byte(hashString))
+	if err != nil {
+		return nil, fmt.Errorf("unable to write the encoded results to the hash: %w", err)
+	}
+	id := fmt.Sprintf("%d", h.Sum32())
+	return &id, nil
+}

--- a/internal/provider/data_variables_test.go
+++ b/internal/provider/data_variables_test.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestDataVariables(t *testing.T) {
+	checks := resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr("data.ns_variables.this", "input_env_variables.%", "6"),
+		resource.TestCheckResourceAttr("data.ns_variables.this", "input_secrets.%", "1"),
+		resource.TestCheckResourceAttr("data.ns_variables.this", "env_variable_keys.#", "5"),
+		resource.TestCheckResourceAttr("data.ns_variables.this", "env_variables.%", "5"),
+		resource.TestCheckResourceAttr("data.ns_variables.this", "env_variables.FEATURE_FLAG_0115", "true"),
+		resource.TestCheckResourceAttr("data.ns_variables.this", "env_variables.IDENTIFIER", "primary.acme-api.dev"),
+		resource.TestCheckResourceAttr("data.ns_variables.this", "secret_keys.#", "2"),
+		resource.TestCheckResourceAttr("data.ns_variables.this", "secrets.%", "2"),
+		resource.TestCheckResourceAttr("data.ns_variables.this", "secrets.POSTGRES_URL", "postgres://user:pass@host:port/db"),
+		resource.TestCheckResourceAttr("data.ns_variables.this", "secrets.DATABASE_URL", "postgres://user:pass@host:port/db"),
+	)
+
+	t.Run("sets up attributes properly hard-coded", func(t *testing.T) {
+		config := fmt.Sprintf(`
+provider "ns" {
+  organization = "org0"
+}
+data "ns_variables" "this" {
+	input_env_variables = {
+		NULLSTONE_STACK = "primary"
+		NULLSTONE_BLOCK = "acme-api"
+		NULLSTONE_ENV = "dev"
+		FEATURE_FLAG_0115 = "true"
+		DATABASE_URL = "{{ POSTGRES_URL }}"
+		IDENTIFIER = "{{ NULLSTONE_STACK }}.{{ NULLSTONE_BLOCK }}.{{ NULLSTONE_ENV }}"
+	}
+	input_secrets = {
+		POSTGRES_URL = "postgres://user:pass@host:port/db"
+	}
+}
+`)
+		getNsConfig, _ := mockNs(nil)
+		getTfeConfig, _ := mockTfe(nil)
+
+		resource.UnitTest(t, resource.TestCase{
+			ProtoV5ProviderFactories: protoV5ProviderFactories(getNsConfig, getTfeConfig, nil),
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check:  checks,
+				},
+			},
+		})
+	})
+}

--- a/internal/provider/data_variables_test.go
+++ b/internal/provider/data_variables_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestDataVariables(t *testing.T) {
 	checks := resource.ComposeTestCheckFunc(
-		resource.TestCheckResourceAttr("data.ns_variables.this", "input_env_variables.%", "7"),
+		resource.TestCheckResourceAttr("data.ns_variables.this", "input_env_variables.%", "6"),
 		resource.TestCheckResourceAttr("data.ns_variables.this", "input_secrets.%", "1"),
-		resource.TestCheckResourceAttr("data.ns_variables.this", "env_variable_keys.#", "6"),
-		resource.TestCheckResourceAttr("data.ns_variables.this", "env_variables.%", "6"),
+		resource.TestCheckResourceAttr("data.ns_variables.this", "env_variable_keys.#", "5"),
+		resource.TestCheckResourceAttr("data.ns_variables.this", "env_variables.%", "5"),
 		resource.TestCheckResourceAttr("data.ns_variables.this", "env_variables.FEATURE_FLAG_0115", "true"),
 		resource.TestCheckResourceAttr("data.ns_variables.this", "env_variables.IDENTIFIER", "primary.acme-api.dev"),
 		resource.TestCheckResourceAttr("data.ns_variables.this", "secret_keys.#", "2"),

--- a/internal/provider/data_variables_test.go
+++ b/internal/provider/data_variables_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestDataVariables(t *testing.T) {
 	checks := resource.ComposeTestCheckFunc(
-		resource.TestCheckResourceAttr("data.ns_variables.this", "input_env_variables.%", "6"),
+		resource.TestCheckResourceAttr("data.ns_variables.this", "input_env_variables.%", "7"),
 		resource.TestCheckResourceAttr("data.ns_variables.this", "input_secrets.%", "1"),
-		resource.TestCheckResourceAttr("data.ns_variables.this", "env_variable_keys.#", "5"),
-		resource.TestCheckResourceAttr("data.ns_variables.this", "env_variables.%", "5"),
+		resource.TestCheckResourceAttr("data.ns_variables.this", "env_variable_keys.#", "6"),
+		resource.TestCheckResourceAttr("data.ns_variables.this", "env_variables.%", "6"),
 		resource.TestCheckResourceAttr("data.ns_variables.this", "env_variables.FEATURE_FLAG_0115", "true"),
 		resource.TestCheckResourceAttr("data.ns_variables.this", "env_variables.IDENTIFIER", "primary.acme-api.dev"),
 		resource.TestCheckResourceAttr("data.ns_variables.this", "secret_keys.#", "2"),
@@ -32,7 +32,7 @@ data "ns_variables" "this" {
 		NULLSTONE_BLOCK = "acme-api"
 		NULLSTONE_ENV = "dev"
 		FEATURE_FLAG_0115 = "true"
-		DATABASE_URL = "{{ POSTGRES_URL }}"
+		DATABASE_URL = "{{POSTGRES_URL}}"
 		IDENTIFIER = "{{ NULLSTONE_STACK }}.{{ NULLSTONE_BLOCK }}.{{ NULLSTONE_ENV }}"
 	}
 	input_secrets = {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -54,6 +54,7 @@ func newProviderServer(version string, fn func() (api.Config, *tfe.Config, PlanC
 	s.MustRegisterDataSource("ns_subdomain", newDataSubdomain)
 	s.MustRegisterDataSource("ns_domain", newDataDomain)
 	s.MustRegisterDataSource("ns_app_env", newDataAppEnv)
+	s.MustRegisterDataSource("ns_variables", newDataVariables)
 
 	// resources
 	s.MustRegisterResource("ns_autogen_subdomain", newResourceAutogenSubdomain)


### PR DESCRIPTION
This PR adds a new data_source to the Nullstone provider. This data_source is used like the following:

```
data "ns_variables" "this" {
	input_env_variables = {
		NULLSTONE_STACK = "primary"
		NULLSTONE_BLOCK = "acme-api"
		NULLSTONE_ENV = "dev"
		FEATURE_FLAG_0115 = "true"
		DATABASE_URL = "{{POSTGRES_URL}}"
		IDENTIFIER = "{{ NULLSTONE_STACK }}.{{ NULLSTONE_BLOCK }}.{{ NULLSTONE_ENV }}"
	}
	input_secrets = {
		POSTGRES_URL = "postgres://user:pass@host:port/db"
	}
}
```

If an env variable or secret contains `{{ KEY_NAME }}` anywhere in their value (and the key name matches another env variable or secret), the placeholder will be replaced with the value of the other env variable or secret.

If an env variable is interpolated with a secret, the env variable will be transferred to the list of secrets.

No matter how many placeholders are in an env variable or secret's value, they will all be interpolated.
