### PR TITLE
Allow env vars to override ns_app_env.version and ns_app_env.commit_sha

### DIFF
--- a/internal/provider/autogen_subdomain_test.go
+++ b/internal/provider/autogen_subdomain_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gorilla/mux"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
 	"net/http"
+	"strconv"
 )
 
 func mockNsServerWithAutogenSubdomains(autogenSubdomains map[string]map[string]map[string]*types.AutogenSubdomain) http.Handler {
@@ -27,8 +28,12 @@ func mockNsServerWithAutogenSubdomains(autogenSubdomains map[string]map[string]m
 		return as
 	}
 	createAutogenSubdomain := func(orgName string, subdomainId string, envId string) types.AutogenSubdomain {
+		id, _ := strconv.ParseInt(subdomainId, 64, 10)
+		if id == 0 {
+			id = 1
+		}
 		as := types.AutogenSubdomain{
-			IdModel:     types.IdModel{Id: 1},
+			IdModel:     types.IdModel{Id: id},
 			DnsName:     "xyz123",
 			OrgName:     orgName,
 			DomainName:  "nullstone.app",

--- a/internal/provider/autogen_subdomain_test.go
+++ b/internal/provider/autogen_subdomain_test.go
@@ -24,6 +24,28 @@ func mockNsServerWithAutogenSubdomains(autogenSubdomains map[string]map[string]m
 		}
 		return result
 	}
+	createAutogenSubdomain := func(orgName string, subdomainId string, envId string) types.AutogenSubdomain {
+		as := types.AutogenSubdomain{
+			IdModel:     types.IdModel{Id: 1},
+			DnsName:     "xyz123",
+			OrgName:     orgName,
+			DomainName:  "nullstone.app",
+			Fqdn:        "xyz123.nullstone.app.",
+			Nameservers: []string{},
+		}
+		orgScoped, ok := autogenSubdomains[orgName]
+		if !ok {
+			orgScoped = map[string]map[string]*types.AutogenSubdomain{}
+			autogenSubdomains[orgName] = orgScoped
+		}
+		subdomainScoped, ok := orgScoped[subdomainId]
+		if !ok {
+			subdomainScoped = map[string]*types.AutogenSubdomain{}
+			orgScoped[subdomainId] = subdomainScoped
+		}
+		subdomainScoped[envId] = &as
+		return as
+	}
 
 	router := mux.NewRouter()
 	router.
@@ -32,14 +54,7 @@ func mockNsServerWithAutogenSubdomains(autogenSubdomains map[string]map[string]m
 		HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			orgName := mux.Vars(r)["orgName"]
 			// NOTE: We're going to always return the same one we created instead of being random
-			autogenSubdomain := types.AutogenSubdomain{
-				IdModel:     types.IdModel{Id: 1},
-				DnsName:     "xyz123",
-				OrgName:     orgName,
-				DomainName:  "nullstone.app",
-				Fqdn:        "xyz123.nullstone.app.",
-				Nameservers: []string{},
-			}
+			autogenSubdomain := createAutogenSubdomain(orgName, "", "")
 			raw, _ := json.Marshal(autogenSubdomain)
 			w.Write(raw)
 		})

--- a/internal/provider/data_app_env.go
+++ b/internal/provider/data_app_env.go
@@ -7,6 +7,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"gopkg.in/nullstone-io/go-api-client.v0"
 	"gopkg.in/nullstone-io/go-api-client.v0/types"
+	"os"
+)
+
+const (
+	DeployInfoVersionEnvVar   = "NULLSTONE_DEPLOY_VERSION"
+	DeployInfoCommitShaEnvVar = "NULLSTONE_DEPLOY_COMMIT_SHA"
 )
 
 type dataAppEnv struct {
@@ -125,6 +131,14 @@ func (d *dataAppEnv) Read(ctx context.Context, config map[string]tftypes.Value) 
 			appEnvVersion = appEnv.Version
 			appEnvCommitSha = appEnv.CommitSha
 		}
+	}
+
+	// If present, override with env variables
+	if val := os.Getenv(DeployInfoVersionEnvVar); val != "" {
+		appEnvVersion = val
+	}
+	if val := os.Getenv(DeployInfoCommitShaEnvVar); val != "" {
+		appEnvCommitSha = val
 	}
 
 	return map[string]tftypes.Value{

--- a/website/docs/d/app_env.markdown
+++ b/website/docs/d/app_env.markdown
@@ -38,4 +38,6 @@ locals {
 ## Attributes Reference
 
 * `version` - The version of the latest deployment of this application in the specific environment.
+  The `NULLSTONE_DEPLOY_VERSION` environment variable will override this value.
 * `commit_sha` - The commit SHA of the latest deployment of this application in this specific environment.
+  The `NULLSTONE_DEPLOY_COMMIT_SHA` environment variable will override this value.


### PR DESCRIPTION
This introduces the ability to override `data.ns_app_env` attributes using env variables.
- `version`: `NULLSTONE_DEPLOY_VERSION`
- `commit_sha`: `NULLSTONE_DEPLOY_COMMIT_SHA`