### PR TITLE
Built standalone implementation of env vars interpolation

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  GO_VERSION: "1.18"
+  GO_VERSION: "1.21"
 
 jobs:
   tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.21
       -
         name: Import GPG key
         id: import_gpg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.24 (Oct 25, 2025)
+
+BUG FIXES:
+
+* Fixed issues with `data.ns_secret_keys` and `data.ns_env_variables` producing inconsistent results.
+
 ## 0.6.23 (May 16, 2024)
 
 FEATURES:

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,16 @@
 module github.com/nullstone-io/terraform-provider-ns
 
-go 1.18
+go 1.21
 
 require (
+	github.com/google/go-cmp v0.5.7
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-argmapper v0.0.0-20200721221215-04ae500ede3b
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-tfe v0.11.1
 	github.com/hashicorp/terraform-plugin-go v0.7.1
+	github.com/hashicorp/terraform-plugin-log v0.2.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
 	github.com/nullstone-io/module v0.2.8
 	github.com/stretchr/testify v1.7.0
@@ -30,7 +32,6 @@ require (
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/go-git/go-git/v5 v5.4.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
@@ -48,7 +49,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.15.0 // indirect
 	github.com/hashicorp/terraform-json v0.13.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.2.1 // indirect
 	github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896 // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,7 @@ github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyX
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -607,6 +608,7 @@ golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=
+golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -671,6 +673,7 @@ golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
+golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/provider/data_secret_keys.go
+++ b/internal/provider/data_secret_keys.go
@@ -2,12 +2,10 @@ package provider
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"regexp"
 )
 
 type dataSecretKeys struct {
@@ -59,8 +57,8 @@ func (*dataSecretKeys) Schema(ctx context.Context) *tfprotov5.Schema {
 }
 
 func (d *dataSecretKeys) Validate(ctx context.Context, config map[string]tftypes.Value) ([]*tfprotov5.Diagnostic, error) {
-	inputEnvVariables := extractMapFromConfig(config, "input_env_variables")
-	inputSecretKeys := extractSetFromConfig(config, "input_secret_keys")
+	inputEnvVariables := TfValueToMap(config["input_env_variables"])
+	inputSecretKeys := TfSetValueToStringSlice(config["input_secret_keys"])
 
 	errors := make([]*tfprotov5.Diagnostic, 0)
 	for key, _ := range inputEnvVariables {
@@ -73,7 +71,7 @@ func (d *dataSecretKeys) Validate(ctx context.Context, config map[string]tftypes
 		}
 	}
 	for _, key := range inputSecretKeys {
-		if !validEnvVariableKey(extractStringFromTfValue(key)) {
+		if !validEnvVariableKey(key) {
 			errors = append(errors, &tfprotov5.Diagnostic{
 				Severity: tfprotov5.DiagnosticSeverityError,
 				Summary:  fmt.Sprintf("Invalid environment variable key: %s", key),
@@ -86,68 +84,31 @@ func (d *dataSecretKeys) Validate(ctx context.Context, config map[string]tftypes
 }
 
 func (d *dataSecretKeys) Read(ctx context.Context, config map[string]tftypes.Value) (map[string]tftypes.Value, []*tfprotov5.Diagnostic, error) {
-	inputEnvVariables := extractMapFromConfig(config, "input_env_variables")
-	inputSecretKeys := extractSetFromConfig(config, "input_secret_keys")
+	inputEnvVariables := config["input_env_variables"]
+	inputSecretKeys := config["input_secret_keys"]
 
 	tflog.Debug(ctx, "input_env_variables", inputEnvVariables)
 	tflog.Debug(ctx, "input_secret_keys", inputSecretKeys)
 
-	// make sure we copy these so our changes below don't affect the original values
-	envVariables := copyMap(inputEnvVariables)
-
-	// first pull out any env variables that contain refs to secrets in their interpolation
-	refRegexPattern := "{{\\s*secret\\((.+)\\)\\s*}}"
-	regex := regexp.MustCompile(refRegexPattern)
-	for k, v := range envVariables {
-		// if extractStringFromTfValue(v) contains the regex pattern, and the interpolation is set to `secret(arn)`
-		// then we need to skip this replacement and output the arn as a secret_ref
-		if regex.MatchString(extractStringFromTfValue(v)) {
-			delete(envVariables, k)
-		}
+	// Shuffle secret keys slice into a map so we can use Interpolate to check secret keys
+	inputSecrets := map[string]string{}
+	for _, v := range TfSetValueToStringSlice(inputSecretKeys) {
+		inputSecrets[v] = ""
 	}
 
-	// make sure we copy these so our changes below don't affect the original values
-	secretKeys := copySet(inputSecretKeys)
+	ev := NewEnvVars(TfValueToMap(inputEnvVariables), inputSecrets)
+	ev.Interpolate()
 
-	regexPattern := "{{\\s*%s\\s*}}"
-	// loop through and determine if any of the environment variables contain interpolation using any of the secret keys
-	//   if they do, add their keys to the final set of secret keys
-	added := map[string]bool{}
-	for _, secretKey := range inputSecretKeys {
-		regex := regexp.MustCompile(fmt.Sprintf(regexPattern, extractStringFromTfValue(secretKey)))
-		// first try and replace in the env variables
-		for k, v := range envVariables {
-			// don't add the key more than once, the "added" map keeps track of whether it has already been added
-			if added[k] {
-				continue
-			}
-			if found := regex.MatchString(extractStringFromTfValue(v)); found {
-				secretKeys = append(secretKeys, tftypes.NewValue(tftypes.String, k))
-				added[k] = true
-			}
-		}
-	}
-
-	// calculate the unique id for this data source based on a hash of the resulting env variables and secrets
-	id := d.HashFromValues(secretKeys)
+	id := ev.KeysHash()
+	secretKeys := ev.SecretKeys()
 
 	tflog.Debug(ctx, "id", id)
 	tflog.Debug(ctx, "secret_keys", secretKeys)
 
 	return map[string]tftypes.Value{
 		"id":                  tftypes.NewValue(tftypes.String, id),
-		"input_env_variables": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, inputEnvVariables),
-		"input_secret_keys":   tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, inputSecretKeys),
-		"secret_keys":         tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, secretKeys),
+		"input_env_variables": inputEnvVariables,
+		"input_secret_keys":   inputSecretKeys,
+		"secret_keys":         SliceToTfSet(secretKeys),
 	}, nil, nil
-}
-
-func (d *dataSecretKeys) HashFromValues(secretKeys []tftypes.Value) string {
-	hashString := ""
-	for _, v := range secretKeys {
-		hashString += fmt.Sprintf("%s=%s;", v, extractStringFromTfValue(v))
-	}
-
-	sum := sha256.Sum256([]byte(hashString))
-	return fmt.Sprintf("%x", sum)
 }

--- a/internal/provider/data_secret_keys_test.go
+++ b/internal/provider/data_secret_keys_test.go
@@ -10,16 +10,6 @@ import (
 func TestSecretKeys(t *testing.T) {
 	arn := "arn:aws:secretsmanager:us-east-1:0123456789012:secret:my_little_secret"
 
-	checks := resource.ComposeTestCheckFunc(
-		resource.TestCheckResourceAttr("data.ns_secret_keys.this", "input_env_variables.%", "8"),
-		resource.TestCheckResourceAttr("data.ns_secret_keys.this", "input_secret_keys.#", "2"),
-		resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.#", "4"),
-		resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.0", "DATABASE_URL"),
-		resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.1", "DUPLICATE_TEST"),
-		resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.2", "POSTGRES_URL"),
-		resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.3", "SECRET_KEY_BASE"),
-	)
-
 	t.Run("sets up attributes properly hard-coded", func(t *testing.T) {
 		config := fmt.Sprintf(`
 provider "ns" {
@@ -44,6 +34,111 @@ data "ns_secret_keys" "this" {
 `, arn)
 		getNsConfig, _ := mockNs(nil)
 		getTfeConfig, _ := mockTfe(nil)
+
+		checks := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("data.ns_secret_keys.this", "input_env_variables.%", "8"),
+			resource.TestCheckResourceAttr("data.ns_secret_keys.this", "input_secret_keys.#", "2"),
+			resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.#", "4"),
+			resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.0", "DATABASE_URL"),
+			resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.1", "DUPLICATE_TEST"),
+			resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.2", "POSTGRES_URL"),
+			resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.3", "SECRET_KEY_BASE"),
+		)
+
+		resource.UnitTest(t, resource.TestCase{
+			ProtoV5ProviderFactories: protoV5ProviderFactories(getNsConfig, getTfeConfig, nil),
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check:  checks,
+				},
+			},
+		})
+	})
+
+	t.Run("real scenario 1", func(t *testing.T) {
+		config := fmt.Sprintf(`
+provider "ns" {
+  organization = "org0"
+}
+variable "env_vars" {
+	type    = map(string)
+	default = {
+		"OTEL_EXPORTER_OTLP_ENDPOINT" = "https://otlp.uptrace.dev"
+		"OTEL_METRICS_EXEMPLAR_FILTER" = "always_on"
+		"OTEL_METRICS_EXPORTER" = "otlp"
+		"OTEL_METRIC_EXPORT_INTERVAL" = "15000"
+		"OTEL_TRACES_EXPORTER" = "otlp"
+		"OTEL_TRACES_SAMPLER" = "always_on"
+		"POSTGRES_SLOW_QUERY" = "1m"
+		"SERVICE_DOMAIN" = "{{ NULLSTONE_ENV }}"
+	}
+}
+variable "secrets" {
+	type      = map(string)
+    sensitive = true
+	default   = {
+		"OTEL_EXPORTER_OTLP_HEADERS" = "uptrace-dsn=https://XgHrvhymCpGP20K7vUNp2A@api.uptrace.dev?grpc=4317"
+  		"ROLLBAR_ACCESS_TOKEN" = "39ec403290c94fc6b81d17a308a2909d"
+    }
+}
+locals {
+	cap_env_vars = {
+		"POSTGRES_DB" = "nullfire"
+		"POSTGRES_HOST" = "raspberry-lizard-iznie.cs4cyqrf5rxq.us-east-1.rds.amazonaws.com"
+		"POSTGRES_USER" = "nullfire-vipgg"
+		"REDIS_HOST" = "master.sangria-snail-ttfuq.ejk9gq.use1.cache.amazonaws.com"
+		"REDIS_PORT" = "6379"
+		"TEMPORAL_HOSTPORT" = "core-prod-bvhai.i0cev.tmprl.cloud:7233"
+		"TEMPORAL_NAMESPACE" = "core-prod-bvhai.i0cev"
+		"TEMPORAL_TLS_CERT" = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVOVENDQXAyZ0F3SUJBZ0lSQVBqYTRWMkI1bmtwSTVuc25JN0pEbk13RFFZSktvWklodmNOQVFFTEJRQXcKS3pFU01CQUdBMVVFQ2hNSlRuVnNiSE4wYjI1bE1SVXdFd1lEVlFRREV3eHVkV3hzYzNSdmJtVXVhVzh3SGhjTgpNalF3TkRJNU1qTTBOelF6V2hjTk16UXdOREkzTWpNME56UXpXakFyTVJJd0VBWURWUVFLRXdsT2RXeHNjM1J2CmJtVXhGVEFUQmdOVkJBTVRERzUxYkd4emRHOXVaUzVwYnpDQ0FhSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnR1AKQURDQ0FZb0NnZ0dCQU1DYkt4QVY5WndmT1BURExacE9TUjh1MzlsWGE1a29kZTdoRjJSNEJ4Mng5cS8yR2RNVQpUVEZMVjYvcFo2eGhoOUl0N1ZEUjJRQUUzQXgyNnhPWnZUck9Jd0RaWEZVbXdQMG9jcEZXVENEVjJhb0Z2cUk3Cno5NmR2SGsyTUlHb0RWWVc5ejBoS0NhOEdrSnpLbG55dWM3ekZONUhoQzJzRjlhdzREMVlSTGcwK0t3NWdsZUwKamFLSFpySVlRMFA3Z040QVJFeDNRd2QrQ0d4VWtXQysyWnRmN01PK3dSeTBESncxcW0wRVVBNTZNWlM1SnpRQwpuZnFHTXFGNmNrYlRuZEFFQ0ZKRERka2YwRGpyUVkrallETnFKVFlWSCt4eDMycWpyTDMvYkxSdGhwK0ZPUlJQCnR3bUFzWHNZU1FpWjB1N2s3WUZud1ZPUWRGNHB0SHFRMzByZVlXK0tTV2tlOVpaSEJDclExeStqV2hwRnh3cTAKTTZrS3BFajFSZDA4aFVCTjdGYlJ6TTlkdzU1OHpOUGZDYklkdnYzYnpKdzBSb1RZaWVwb0F4NGFkWlJkcWx4bApQUFNPZHpJUi9CbUhZTkZ6UnVhSllIdUtGL1NtUmJWVWNTT0k0cG9pR3ZoNHF2T1pVNHFGRmlCaXpndWhxaU1zCk5FTVc2em5ZRGxnNFB3SURBUUFCbzFRd1VqQU9CZ05WSFE4QkFmOEVCQU1DQmFBd0hRWURWUjBsQkJZd0ZBWUkKS3dZQkJRVUhBd0VHQ0NzR0FRVUZCd01DTUF3R0ExVWRFd0VCL3dRQ01BQXdFd1lEVlIwUkJBd3dDb0lJYm5WcwpiR1pwY21Vd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dHQkFESVdLeFd0WG84S3hDT1liZDMwZGJMSTcvbTRtOU4zClMyTGYraXU0ZzJKTndqcXhmODRIemVUK3ZGRG14MExWbHI1Y2pPbXU3bW9jdXo2bFZUNmNGc0FXaXpuQVcwZ00KQTFMRnZzSkY4RGxsWHI4ZE50NnIyd0poOVoycFhCdWFkOWxWSU0zUTJLa2xKbW9tY3l6T1QxRmFPYzk3RnQ0ZgpMWGtaWkpmZE50YmhNMHJwY0FXTUhXbWhRaTFOcUdIYUtSQzNwMk5VclpyZ0dway9MV0NrSHNBdytHZ3kvZVM2CkJrWEhRSGlrYjFnZFFOVDVNdGlmOXZidUpKSWt4OTRUUHBrZWZmalduWWxsekVRVEtmV2FobzA2VlF1enhQVDgKaEdCb2ZnaDM2SElGOUhFWGNQQm9XT2RNMTdJV0Q0RS8yZEZmQ2hOTlhQd2hwV0xLVjR3Lzk4aERldUh2Sk5UUgpSMnY5Z2xzSUlvQmpPWDlLR212T3BadFRIOGtBeTQybXh2aEVSdFZnNVdKUlcvbG1CdU14a0d6RWJ1UUpjTVRJCjVqRlhLNndZQjBjTkVlcWxyVnhPQ0ZvN3pBV29TdzdIOGFySXhLc29Gbnd2bHNSU1BialdyaHA3bXZhUmdnUWUKK29nMnhjeEV1NENUOE9yZzdLbFhQRTRqa0hua010eFl5Zz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+	}
+	cap_secrets = {
+		"POSTGRES_PASSWORD" = sensitive("something")
+		"POSTGRES_URL" = sensitive("something")
+		"REDIS_AUTH_TOKEN" = sensitive("something")
+		"REDIS_URL" = sensitive("something")
+		"TEMPORAL_TLS_KEY" = sensitive("something")
+    }
+}
+locals {
+	standard_env_vars = tomap({
+		NULLSTONE_STACK         = "core"
+		NULLSTONE_APP           = "api1"
+		NULLSTONE_ENV           = "dev"
+		NULLSTONE_VERSION       = "0.2.3"
+	})
+	
+	input_env_vars    = merge(local.standard_env_vars, local.cap_env_vars, var.env_vars)
+	input_secrets     = merge(local.cap_secrets, var.secrets)
+	input_secret_keys = nonsensitive(concat(keys(local.cap_secrets), keys(var.secrets)))
+}
+data "ns_env_variables" "this" {
+  input_env_variables = local.input_env_vars
+  input_secrets       = local.input_secrets
+}
+data "ns_secret_keys" "this" {
+  //input_env_variables = local.input_env_vars
+  //input_secret_keys   = local.input_secret_keys
+  input_env_variables = local.input_env_vars
+  input_secret_keys   = nonsensitive(keys(local.input_secrets))
+}
+`)
+		getNsConfig, _ := mockNs(nil)
+		getTfeConfig, _ := mockTfe(nil)
+
+		checks := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("data.ns_secret_keys.this", "input_env_variables.%", "20"),
+			resource.TestCheckResourceAttr("data.ns_secret_keys.this", "input_secret_keys.#", "7"),
+			resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.#", "7"),
+			resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.0", "OTEL_EXPORTER_OTLP_HEADERS"),
+			resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.1", "POSTGRES_PASSWORD"),
+			resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.2", "POSTGRES_URL"),
+			resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.3", "REDIS_AUTH_TOKEN"),
+			resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.4", "REDIS_URL"),
+			resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.5", "ROLLBAR_ACCESS_TOKEN"),
+			resource.TestCheckResourceAttr("data.ns_secret_keys.this", "secret_keys.6", "TEMPORAL_TLS_KEY"),
+		)
 
 		resource.UnitTest(t, resource.TestCase{
 			ProtoV5ProviderFactories: protoV5ProviderFactories(getNsConfig, getTfeConfig, nil),

--- a/internal/provider/env_vars.go
+++ b/internal/provider/env_vars.go
@@ -1,0 +1,168 @@
+package provider
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+var (
+	secretRefRegex               = regexp.MustCompile("{{\\s*secret\\((.+)\\)\\s*}}")
+	interpolationRefRegexPattern = "{{\\s*%s\\s*}}"
+)
+
+type EnvVars map[string]EnvVar
+
+func NewEnvVars(envVars map[string]string, secrets map[string]string) EnvVars {
+	mixed := EnvVars{}
+	for k, v := range envVars {
+		mixed[k] = EnvVar{Value: v}
+	}
+	for k, v := range secrets {
+		mixed[k] = EnvVar{Value: v, IsSensitive: true}
+	}
+	return mixed
+}
+
+type EnvVar struct {
+	Value       string
+	IsSensitive bool
+	SecretRef   *string
+}
+
+func (m EnvVars) EnvVars() map[string]string {
+	result := map[string]string{}
+	for k, v := range m {
+		if v.SecretRef == nil && !v.IsSensitive {
+			result[k] = v.Value
+		}
+	}
+	return result
+}
+
+func (m EnvVars) Secrets() map[string]string {
+	result := map[string]string{}
+	for k, v := range m {
+		if v.IsSensitive {
+			result[k] = v.Value
+		}
+	}
+	return result
+}
+
+func (m EnvVars) SecretRefs() map[string]string {
+	result := map[string]string{}
+	for k, v := range m {
+		if v.SecretRef != nil {
+			result[k] = *v.SecretRef
+		}
+	}
+	return result
+}
+
+func (m EnvVars) SecretKeys() []string {
+	result := make([]string, 0)
+	for k, v := range m {
+		if v.IsSensitive {
+			result = append(result, k)
+		}
+	}
+	slices.SortStableFunc(result, strings.Compare)
+	return result
+}
+
+func (m EnvVars) Interpolate() {
+	// 1. Mark env var values with secret ref
+	// Scan all env vars, checking for `{{ secret(...) }}`
+	// Extract the secret ref and attach to the value
+	for k, v := range m {
+		result := secretRefRegex.FindStringSubmatch(v.Value)
+		if len(result) > 1 {
+			secretRef := result[1]
+			v.SecretRef = &secretRef
+			m[k] = v
+		}
+	}
+
+	// 2. Interpolate secrets onto other env vars
+	// This has the potential promote env vars to secrets
+	for k1, v1 := range m.Secrets() {
+		replacer := regexp.MustCompile(fmt.Sprintf(interpolationRefRegexPattern, k1))
+		for k2, v2 := range m.EnvVars() {
+			result := replacer.ReplaceAllString(v2, v1)
+			// if a match was found and replaced, this env variable is now a secret
+			if result != v2 {
+				entry := m[k2]
+				entry.IsSensitive = true
+				entry.Value = result
+				m[k2] = entry
+			}
+		}
+		for k2, v2 := range m.Secrets() {
+			if k2 != k1 {
+				result := replacer.ReplaceAllString(v2, v1)
+				if result != v2 {
+					entry := m[k2]
+					entry.IsSensitive = true
+					entry.Value = result
+					m[k2] = entry
+				}
+			}
+		}
+	}
+
+	// 3. Interpolate env vars onto other env vars/secrets
+	// This will not promote anybody to a secret
+	for k1, v1 := range m.EnvVars() {
+		regex := regexp.MustCompile(fmt.Sprintf(interpolationRefRegexPattern, k1))
+		for k2, v2 := range m.EnvVars() {
+			// we don't want to replace the env variable with itself (this will prevent an infinite loop)
+			if k2 != k1 {
+				result := regex.ReplaceAllString(v2, v1)
+				if result != v2 {
+					entry := m[k2]
+					entry.Value = result
+					m[k2] = entry
+				}
+			}
+		}
+		for k2, v2 := range m.Secrets() {
+			result := regex.ReplaceAllString(v2, v1)
+			if result != v2 {
+				entry := m[k2]
+				entry.Value = result
+				m[k2] = entry
+			}
+		}
+	}
+}
+
+func (m EnvVars) Hash() string {
+	hashString := ""
+	for k, v := range m {
+		sensitive := ""
+		if v.IsSensitive {
+			sensitive = "+"
+		}
+		hashString += fmt.Sprintf("%s=%s%s;", k, v.Value, sensitive)
+	}
+
+	sum := sha256.Sum256([]byte(hashString))
+	return fmt.Sprintf("%x", sum)
+}
+
+func (m EnvVars) KeysHash() string {
+	hashString := ""
+	for k, v := range m {
+		sensitive := ""
+		if v.IsSensitive {
+			sensitive = "+"
+		}
+		hashString += fmt.Sprintf("%s%s;", k, sensitive)
+	}
+
+	sum := sha256.Sum256([]byte(hashString))
+	return fmt.Sprintf("%x", sum)
+}

--- a/internal/provider/env_vars_test.go
+++ b/internal/provider/env_vars_test.go
@@ -1,0 +1,76 @@
+package provider
+
+import (
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+func TestMixedEnvVars_Interpolate(t *testing.T) {
+	tests := []struct {
+		inputEnvVars   map[string]string
+		inputSecrets   map[string]string
+		wantEnvVars    map[string]string
+		wantSecrets    map[string]string
+		wantSecretRefs map[string]string
+		wantSecretKeys []string
+	}{
+		{
+			inputEnvVars: map[string]string{
+				"NULLSTONE_STACK":   "primary",
+				"NULLSTONE_BLOCK":   "acme-api",
+				"NULLSTONE_ENV":     "dev",
+				"FEATURE_FLAG_0115": "true",
+				"DATABASE_URL":      "{{POSTGRES_URL}}",
+				"IDENTIFIER":        "{{ NULLSTONE_STACK }}.{{ NULLSTONE_BLOCK }}.{{ NULLSTONE_ENV }}",
+				"DUPLICATE_TEST":    "{{ SECRET_KEY_BASE }}/{{ POSTGRES_URL }}",
+				"VAR_WITH_REF":      "{{ secret(arn:aws:something) }}",
+			},
+			inputSecrets: map[string]string{
+				"POSTGRES_URL":    "fake-value1",
+				"SECRET_KEY_BASE": "fake-value2",
+			},
+			wantEnvVars: map[string]string{
+				"NULLSTONE_STACK":   "primary",
+				"NULLSTONE_BLOCK":   "acme-api",
+				"NULLSTONE_ENV":     "dev",
+				"FEATURE_FLAG_0115": "true",
+				"IDENTIFIER":        "primary.acme-api.dev",
+			},
+			wantSecrets: map[string]string{
+				"DATABASE_URL":    "fake-value1",
+				"POSTGRES_URL":    "fake-value1",
+				"SECRET_KEY_BASE": "fake-value2",
+				"DUPLICATE_TEST":  "fake-value2/fake-value1",
+			},
+			wantSecretRefs: map[string]string{
+				"VAR_WITH_REF": "arn:aws:something",
+			},
+			wantSecretKeys: []string{
+				"DATABASE_URL",
+				"DUPLICATE_TEST",
+				"POSTGRES_URL",
+				"SECRET_KEY_BASE",
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			got := NewEnvVars(test.inputEnvVars, test.inputSecrets)
+			got.Interpolate()
+			if diff := cmp.Diff(test.wantEnvVars, got.EnvVars()); diff != "" {
+				t.Errorf("mismatched env vars (-want, +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.wantSecrets, got.Secrets()); diff != "" {
+				t.Errorf("mismatched secrets (-want, +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.wantSecretRefs, got.SecretRefs()); diff != "" {
+				t.Errorf("mismatched secret refs (-want, +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.wantSecretKeys, got.SecretKeys()); diff != "" {
+				t.Errorf("mismatched secret keys (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I used the existing algorithm for env var interpolation and restructured outside of Terraform constructs.

This new implementation does a few things:
1. Interpolation and tests can be built independent of Terraform constructs.
2. Instead of manipulating maps, entries are *marked* as sensitive and as a secret ref.
3. `data.ns_env_variables` and `data.ns_secret_keys` reuses the same implementation.

### Notes on diagnosis
I suspect that the manipulation to maps is causing an error with the `secret_keys` attribute on `data.ns_env_variables` and `data.ns_secret_keys`. 

I kept seeing `input_env_vars` and `input_secret_keys` mutated when they shouldn't be changed at all.
This suggests that something undesirable was happening when manipulating a map that we were iterating over (*even* with cloning the original input).
