### PR TITLE
Added support for structured valueFrom in env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-## 0.8.3 (Mar 21, 2026)
+## 0.8.3 (Mar 25, 2026)
 
 FEATURES:
 
+* Added Kubernetes `valueFrom` template support in `ns_env_variables`: `k8s.field(...)`, `k8s.configMap(...)`, `k8s.resourceField(...)`, and `k8s.fileKey(...)`.
+* New computed outputs on `ns_env_variables`: `field_refs`, `config_map_refs`, `resource_field_refs`, `file_key_refs`.
+* Malformed K8s templates now produce a diagnostic error at plan time.
 * Added support for configuring capability connections (`ns_connection`) during local development.
 
 ## 0.8.2 (Mar 03, 2026)

--- a/internal/provider/config_utils.go
+++ b/internal/provider/config_utils.go
@@ -112,6 +112,76 @@ func extractStringSliceFromConfig(config map[string]tftypes.Value, key string) (
 	return slice, nil
 }
 
+var fieldRefObjectType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"api_version": tftypes.String,
+	"field_path":  tftypes.String,
+}}
+
+var configMapRefObjectType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"key":      tftypes.String,
+	"name":     tftypes.String,
+	"optional": tftypes.Bool,
+}}
+
+var resourceFieldRefObjectType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"resource":  tftypes.String,
+	"container": tftypes.String,
+	"divisor":   tftypes.String,
+}}
+
+var fileKeyRefObjectType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+	"key":         tftypes.String,
+	"path":        tftypes.String,
+	"volume_name": tftypes.String,
+}}
+
+func FieldRefsToTfValue(refs map[string]FieldRef) tftypes.Value {
+	tfMap := map[string]tftypes.Value{}
+	for k, v := range refs {
+		tfMap[k] = tftypes.NewValue(fieldRefObjectType, map[string]tftypes.Value{
+			"api_version": tftypes.NewValue(tftypes.String, v.ApiVersion),
+			"field_path":  tftypes.NewValue(tftypes.String, v.FieldPath),
+		})
+	}
+	return tftypes.NewValue(tftypes.Map{ElementType: fieldRefObjectType}, tfMap)
+}
+
+func ConfigMapRefsToTfValue(refs map[string]ConfigMapRef) tftypes.Value {
+	tfMap := map[string]tftypes.Value{}
+	for k, v := range refs {
+		tfMap[k] = tftypes.NewValue(configMapRefObjectType, map[string]tftypes.Value{
+			"key":      tftypes.NewValue(tftypes.String, v.Key),
+			"name":     tftypes.NewValue(tftypes.String, v.Name),
+			"optional": tftypes.NewValue(tftypes.Bool, v.Optional),
+		})
+	}
+	return tftypes.NewValue(tftypes.Map{ElementType: configMapRefObjectType}, tfMap)
+}
+
+func ResourceFieldRefsToTfValue(refs map[string]ResourceFieldRef) tftypes.Value {
+	tfMap := map[string]tftypes.Value{}
+	for k, v := range refs {
+		tfMap[k] = tftypes.NewValue(resourceFieldRefObjectType, map[string]tftypes.Value{
+			"resource":  tftypes.NewValue(tftypes.String, v.Resource),
+			"container": tftypes.NewValue(tftypes.String, v.Container),
+			"divisor":   tftypes.NewValue(tftypes.String, v.Divisor),
+		})
+	}
+	return tftypes.NewValue(tftypes.Map{ElementType: resourceFieldRefObjectType}, tfMap)
+}
+
+func FileKeyRefsToTfValue(refs map[string]FileKeyRef) tftypes.Value {
+	tfMap := map[string]tftypes.Value{}
+	for k, v := range refs {
+		tfMap[k] = tftypes.NewValue(fileKeyRefObjectType, map[string]tftypes.Value{
+			"key":         tftypes.NewValue(tftypes.String, v.Key),
+			"path":        tftypes.NewValue(tftypes.String, v.Path),
+			"volume_name": tftypes.NewValue(tftypes.String, v.VolumeName),
+		})
+	}
+	return tftypes.NewValue(tftypes.Map{ElementType: fileKeyRefObjectType}, tfMap)
+}
+
 const envVariableKeyRegex = "^[a-zA-Z_][a-zA-Z0-9_]*$"
 
 func validEnvVariableKey(key string) bool {

--- a/internal/provider/data_env_variables.go
+++ b/internal/provider/data_env_variables.go
@@ -59,6 +59,34 @@ func (*dataEnvVariables) Schema(ctx context.Context) *tfprotov5.Schema {
 			DescriptionKind: tfprotov5.StringKindMarkdown,
 			Computed:        true,
 		},
+		{
+			Name:            "field_refs",
+			Type:            tftypes.Map{ElementType: fieldRefObjectType},
+			Description:     "Map of environment variables that refer to a Kubernetes field for their values.",
+			DescriptionKind: tfprotov5.StringKindMarkdown,
+			Computed:        true,
+		},
+		{
+			Name:            "config_map_refs",
+			Type:            tftypes.Map{ElementType: configMapRefObjectType},
+			Description:     "Map of environment variables that refer to a Kubernetes ConfigMap key for their values.",
+			DescriptionKind: tfprotov5.StringKindMarkdown,
+			Computed:        true,
+		},
+		{
+			Name:            "resource_field_refs",
+			Type:            tftypes.Map{ElementType: resourceFieldRefObjectType},
+			Description:     "Map of environment variables that refer to a Kubernetes resource field for their values.",
+			DescriptionKind: tfprotov5.StringKindMarkdown,
+			Computed:        true,
+		},
+		{
+			Name:            "file_key_refs",
+			Type:            tftypes.Map{ElementType: fileKeyRefObjectType},
+			Description:     "Map of environment variables that refer to a Kubernetes file key for their values.",
+			DescriptionKind: tfprotov5.StringKindMarkdown,
+			Computed:        true,
+		},
 	}
 
 	return &tfprotov5.Schema{
@@ -106,7 +134,17 @@ func (d *dataEnvVariables) Read(ctx context.Context, config map[string]tftypes.V
 	tflog.Debug(ctx, "input_secrets", inputSecrets)
 
 	ev := NewEnvVars(TfValueToMap(inputEnvVariables), TfValueToMap(inputSecrets))
-	ev.Interpolate()
+	if errs := ev.Interpolate(); len(errs) > 0 {
+		diags := make([]*tfprotov5.Diagnostic, 0, len(errs))
+		for _, err := range errs {
+			diags = append(diags, &tfprotov5.Diagnostic{
+				Severity: tfprotov5.DiagnosticSeverityError,
+				Summary:  "Invalid environment variable template",
+				Detail:   err.Error(),
+			})
+		}
+		return nil, diags, nil
+	}
 
 	// calculate the unique id for this data source based on a hash of the resulting env variables and secrets
 	id := ev.Hash()
@@ -125,5 +163,9 @@ func (d *dataEnvVariables) Read(ctx context.Context, config map[string]tftypes.V
 		"env_variables":       MapToTfValue(envVariables),
 		"secrets":             MapToTfValue(secrets),
 		"secret_refs":         MapToTfValue(secretRefs),
+		"field_refs":          FieldRefsToTfValue(ev.FieldRefs()),
+		"config_map_refs":     ConfigMapRefsToTfValue(ev.ConfigMapRefs()),
+		"resource_field_refs": ResourceFieldRefsToTfValue(ev.ResourceFieldRefs()),
+		"file_key_refs":       FileKeyRefsToTfValue(ev.FileKeyRefs()),
 	}, nil, nil
 }

--- a/internal/provider/data_env_variables_test.go
+++ b/internal/provider/data_env_variables_test.go
@@ -11,7 +11,7 @@ func TestDataVariables(t *testing.T) {
 	arn := "arn:aws:secretsmanager:us-east-1:0123456789012:secret:my_little_secret"
 
 	checks := resource.ComposeTestCheckFunc(
-		resource.TestCheckResourceAttr("data.ns_env_variables.this", "input_env_variables.%", "7"),
+		resource.TestCheckResourceAttr("data.ns_env_variables.this", "input_env_variables.%", "11"),
 		resource.TestCheckResourceAttr("data.ns_env_variables.this", "input_secrets.%", "1"),
 		resource.TestCheckResourceAttr("data.ns_env_variables.this", "env_variables.%", "5"),
 		resource.TestCheckResourceAttr("data.ns_env_variables.this", "env_variables.FEATURE_FLAG_0115", "true"),
@@ -21,6 +21,25 @@ func TestDataVariables(t *testing.T) {
 		resource.TestCheckResourceAttr("data.ns_env_variables.this", "secrets.DATABASE_URL", "postgres://user:pass@host:port/db"),
 		resource.TestCheckResourceAttr("data.ns_env_variables.this", "secret_refs.%", "1"),
 		resource.TestCheckResourceAttr("data.ns_env_variables.this", "secret_refs.VAR_WITH_REF", arn),
+		// field_refs
+		resource.TestCheckResourceAttr("data.ns_env_variables.this", "field_refs.%", "1"),
+		resource.TestCheckResourceAttr("data.ns_env_variables.this", "field_refs.IP.api_version", "v1"),
+		resource.TestCheckResourceAttr("data.ns_env_variables.this", "field_refs.IP.field_path", "status.podIP"),
+		// config_map_refs
+		resource.TestCheckResourceAttr("data.ns_env_variables.this", "config_map_refs.%", "1"),
+		resource.TestCheckResourceAttr("data.ns_env_variables.this", "config_map_refs.CM.key", "my-key"),
+		resource.TestCheckResourceAttr("data.ns_env_variables.this", "config_map_refs.CM.name", "my-cm"),
+		resource.TestCheckResourceAttr("data.ns_env_variables.this", "config_map_refs.CM.optional", "true"),
+		// resource_field_refs
+		resource.TestCheckResourceAttr("data.ns_env_variables.this", "resource_field_refs.%", "1"),
+		resource.TestCheckResourceAttr("data.ns_env_variables.this", "resource_field_refs.RES.resource", "limits.cpu"),
+		resource.TestCheckResourceAttr("data.ns_env_variables.this", "resource_field_refs.RES.container", ""),
+		resource.TestCheckResourceAttr("data.ns_env_variables.this", "resource_field_refs.RES.divisor", ""),
+		// file_key_refs
+		resource.TestCheckResourceAttr("data.ns_env_variables.this", "file_key_refs.%", "1"),
+		resource.TestCheckResourceAttr("data.ns_env_variables.this", "file_key_refs.FK.key", "MY_VAR"),
+		resource.TestCheckResourceAttr("data.ns_env_variables.this", "file_key_refs.FK.path", "config.env"),
+		resource.TestCheckResourceAttr("data.ns_env_variables.this", "file_key_refs.FK.volume_name", "config-vol"),
 	)
 
 	t.Run("sets up attributes properly hard-coded", func(t *testing.T) {
@@ -37,6 +56,10 @@ data "ns_env_variables" "this" {
 		DATABASE_URL = "{{POSTGRES_URL}}"
 		IDENTIFIER = "{{ NULLSTONE_STACK }}.{{ NULLSTONE_BLOCK }}.{{ NULLSTONE_ENV }}"
 		VAR_WITH_REF = "{{ secret(%s) }}"
+		IP = "{{ k8s.field(v1, status.podIP) }}"
+		CM = "{{ k8s.configMap(my-key, my-cm, true) }}"
+		RES = "{{ k8s.resourceField(limits.cpu) }}"
+		FK = "{{ k8s.fileKey(MY_VAR, config.env, config-vol) }}"
 	}
 	input_secrets = {
 		POSTGRES_URL = "postgres://user:pass@host:port/db"

--- a/internal/provider/data_secret_keys.go
+++ b/internal/provider/data_secret_keys.go
@@ -97,7 +97,17 @@ func (d *dataSecretKeys) Read(ctx context.Context, config map[string]tftypes.Val
 	}
 
 	ev := NewEnvVars(TfValueToMap(inputEnvVariables), inputSecrets)
-	ev.Interpolate()
+	if errs := ev.Interpolate(); len(errs) > 0 {
+		diags := make([]*tfprotov5.Diagnostic, 0, len(errs))
+		for _, err := range errs {
+			diags = append(diags, &tfprotov5.Diagnostic{
+				Severity: tfprotov5.DiagnosticSeverityError,
+				Summary:  "Invalid environment variable template",
+				Detail:   err.Error(),
+			})
+		}
+		return nil, diags, nil
+	}
 
 	id := ev.KeysHash()
 	secretKeys := ev.SecretKeys()

--- a/internal/provider/env_vars.go
+++ b/internal/provider/env_vars.go
@@ -10,6 +10,10 @@ import (
 
 var (
 	secretRefRegex               = regexp.MustCompile("{{\\s*secret\\((.+)\\)\\s*}}")
+	k8sFieldRefRegex             = regexp.MustCompile("{{\\s*k8s\\.field\\((.+)\\)\\s*}}")
+	k8sConfigMapRefRegex         = regexp.MustCompile("{{\\s*k8s\\.configMap\\((.+)\\)\\s*}}")
+	k8sResourceFieldRefRegex     = regexp.MustCompile("{{\\s*k8s\\.resourceField\\((.+)\\)\\s*}}")
+	k8sFileKeyRefRegex           = regexp.MustCompile("{{\\s*k8s\\.fileKey\\((.+)\\)\\s*}}")
 	interpolationRefRegexPattern = "{{\\s*%s\\s*}}"
 )
 
@@ -27,15 +31,42 @@ func NewEnvVars(envVars map[string]string, secrets map[string]string) EnvVars {
 }
 
 type EnvVar struct {
-	Value       string
-	IsSensitive bool
-	SecretRef   *string
+	Value            string
+	IsSensitive      bool
+	SecretRef        *string
+	FieldRef         *FieldRef
+	ConfigMapRef     *ConfigMapRef
+	ResourceFieldRef *ResourceFieldRef
+	FileKeyRef       *FileKeyRef
+}
+
+type FieldRef struct {
+	ApiVersion string
+	FieldPath  string
+}
+
+type ConfigMapRef struct {
+	Key      string
+	Name     string
+	Optional bool
+}
+
+type ResourceFieldRef struct {
+	Resource  string
+	Container string
+	Divisor   string
+}
+
+type FileKeyRef struct {
+	Key        string
+	Path       string
+	VolumeName string
 }
 
 func (m EnvVars) EnvVars() map[string]string {
 	result := map[string]string{}
 	for k, v := range m {
-		if v.SecretRef == nil && !v.IsSensitive {
+		if v.SecretRef == nil && v.FieldRef == nil && v.ConfigMapRef == nil && v.ResourceFieldRef == nil && v.FileKeyRef == nil && !v.IsSensitive {
 			result[k] = v.Value
 		}
 	}
@@ -62,6 +93,46 @@ func (m EnvVars) SecretRefs() map[string]string {
 	return result
 }
 
+func (m EnvVars) FieldRefs() map[string]FieldRef {
+	result := map[string]FieldRef{}
+	for k, v := range m {
+		if v.FieldRef != nil {
+			result[k] = *v.FieldRef
+		}
+	}
+	return result
+}
+
+func (m EnvVars) ConfigMapRefs() map[string]ConfigMapRef {
+	result := map[string]ConfigMapRef{}
+	for k, v := range m {
+		if v.ConfigMapRef != nil {
+			result[k] = *v.ConfigMapRef
+		}
+	}
+	return result
+}
+
+func (m EnvVars) ResourceFieldRefs() map[string]ResourceFieldRef {
+	result := map[string]ResourceFieldRef{}
+	for k, v := range m {
+		if v.ResourceFieldRef != nil {
+			result[k] = *v.ResourceFieldRef
+		}
+	}
+	return result
+}
+
+func (m EnvVars) FileKeyRefs() map[string]FileKeyRef {
+	result := map[string]FileKeyRef{}
+	for k, v := range m {
+		if v.FileKeyRef != nil {
+			result[k] = *v.FileKeyRef
+		}
+	}
+	return result
+}
+
 func (m EnvVars) SecretKeys() []string {
 	result := make([]string, 0)
 	for k, v := range m {
@@ -73,16 +144,83 @@ func (m EnvVars) SecretKeys() []string {
 	return result
 }
 
-func (m EnvVars) Interpolate() {
-	// 1. Mark env var values with secret ref
-	// Scan all env vars, checking for `{{ secret(...) }}`
-	// Extract the secret ref and attach to the value
+func parseTemplateArgs(raw string) []string {
+	parts := strings.Split(raw, ",")
+	args := make([]string, 0, len(parts))
+	for _, p := range parts {
+		args = append(args, strings.TrimSpace(p))
+	}
+	return args
+}
+
+func (m EnvVars) Interpolate() []error {
+	var errs []error
+
+	// 1. Mark env var values with secret ref or k8s valueFrom refs
+	// Scan all env vars, checking for `{{ secret(...) }}`, `{{ k8s.field(...) }}`, etc.
+	// Extract the ref and attach to the value
 	for k, v := range m {
 		result := secretRefRegex.FindStringSubmatch(v.Value)
 		if len(result) > 1 {
 			secretRef := result[1]
 			v.SecretRef = &secretRef
 			m[k] = v
+			continue
+		}
+
+		if result = k8sFieldRefRegex.FindStringSubmatch(v.Value); len(result) > 1 {
+			args := parseTemplateArgs(result[1])
+			if len(args) != 2 || args[0] == "" || args[1] == "" {
+				errs = append(errs, fmt.Errorf("env var %q: k8s.field requires 2 arguments (apiVersion, fieldPath), got %q", k, result[1]))
+				continue
+			}
+			v.FieldRef = &FieldRef{ApiVersion: args[0], FieldPath: args[1]}
+			m[k] = v
+			continue
+		}
+
+		if result = k8sConfigMapRefRegex.FindStringSubmatch(v.Value); len(result) > 1 {
+			args := parseTemplateArgs(result[1])
+			if len(args) < 2 || len(args) > 3 || args[0] == "" || args[1] == "" {
+				errs = append(errs, fmt.Errorf("env var %q: k8s.configMap requires 2-3 arguments (key, name[, optional]), got %q", k, result[1]))
+				continue
+			}
+			ref := ConfigMapRef{Key: args[0], Name: args[1]}
+			if len(args) == 3 {
+				ref.Optional = args[2] == "true"
+			}
+			v.ConfigMapRef = &ref
+			m[k] = v
+			continue
+		}
+
+		if result = k8sResourceFieldRefRegex.FindStringSubmatch(v.Value); len(result) > 1 {
+			args := parseTemplateArgs(result[1])
+			if len(args) < 1 || len(args) > 3 || args[0] == "" {
+				errs = append(errs, fmt.Errorf("env var %q: k8s.resourceField requires 1-3 arguments (resource[, container, divisor]), got %q", k, result[1]))
+				continue
+			}
+			ref := ResourceFieldRef{Resource: args[0]}
+			if len(args) >= 2 {
+				ref.Container = args[1]
+			}
+			if len(args) == 3 {
+				ref.Divisor = args[2]
+			}
+			v.ResourceFieldRef = &ref
+			m[k] = v
+			continue
+		}
+
+		if result = k8sFileKeyRefRegex.FindStringSubmatch(v.Value); len(result) > 1 {
+			args := parseTemplateArgs(result[1])
+			if len(args) != 3 || args[0] == "" || args[1] == "" || args[2] == "" {
+				errs = append(errs, fmt.Errorf("env var %q: k8s.fileKey requires 3 arguments (key, path, volumeName), got %q", k, result[1]))
+				continue
+			}
+			v.FileKeyRef = &FileKeyRef{Key: args[0], Path: args[1], VolumeName: args[2]}
+			m[k] = v
+			continue
 		}
 	}
 
@@ -149,6 +287,8 @@ func (m EnvVars) Interpolate() {
 			}
 		}
 	}
+
+	return errs
 }
 
 func (m EnvVars) Hash() string {

--- a/internal/provider/env_vars_test.go
+++ b/internal/provider/env_vars_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -9,14 +8,21 @@ import (
 
 func TestMixedEnvVars_Interpolate(t *testing.T) {
 	tests := []struct {
-		inputEnvVars   map[string]string
-		inputSecrets   map[string]string
-		wantEnvVars    map[string]string
-		wantSecrets    map[string]string
-		wantSecretRefs map[string]string
-		wantSecretKeys []string
+		name                  string
+		inputEnvVars          map[string]string
+		inputSecrets          map[string]string
+		wantEnvVars           map[string]string
+		wantSecrets           map[string]string
+		wantSecretRefs        map[string]string
+		wantFieldRefs         map[string]FieldRef
+		wantConfigMapRefs     map[string]ConfigMapRef
+		wantResourceFieldRefs map[string]ResourceFieldRef
+		wantFileKeyRefs       map[string]FileKeyRef
+		wantSecretKeys        []string
+		wantErrors            int
 	}{
 		{
+			name: "full interpolation with all ref types",
 			inputEnvVars: map[string]string{
 				"NULLSTONE_STACK":    "primary",
 				"NULLSTONE_BLOCK":    "acme-api",
@@ -27,6 +33,12 @@ func TestMixedEnvVars_Interpolate(t *testing.T) {
 				"IDENTIFIER":         "{{ NULLSTONE_STACK }}.{{ NULLSTONE_BLOCK }}.{{ NULLSTONE_ENV }}",
 				"DUPLICATE_TEST":     "{{ SECRET_KEY_BASE }}/{{ POSTGRES_URL }}",
 				"VAR_WITH_REF":       "{{ secret(arn:aws:something) }}",
+				"IP":                 "{{ k8s.field(v1, status.podIP) }}",
+				"CM":                 "{{ k8s.configMap(my-key, my-cm, true) }}",
+				"CM2":                "{{ k8s.configMap(key, name) }}",
+				"RES":                "{{ k8s.resourceField(limits.cpu) }}",
+				"RES2":               "{{ k8s.resourceField(limits.memory, main, 1Mi) }}",
+				"FK":                 "{{ k8s.fileKey(MY_VAR, config.env, config-vol) }}",
 			},
 			inputSecrets: map[string]string{
 				"POSTGRES_URL":    "fake-value1",
@@ -49,6 +61,20 @@ func TestMixedEnvVars_Interpolate(t *testing.T) {
 			wantSecretRefs: map[string]string{
 				"VAR_WITH_REF": "arn:aws:something",
 			},
+			wantFieldRefs: map[string]FieldRef{
+				"IP": {ApiVersion: "v1", FieldPath: "status.podIP"},
+			},
+			wantConfigMapRefs: map[string]ConfigMapRef{
+				"CM":  {Key: "my-key", Name: "my-cm", Optional: true},
+				"CM2": {Key: "key", Name: "name", Optional: false},
+			},
+			wantResourceFieldRefs: map[string]ResourceFieldRef{
+				"RES":  {Resource: "limits.cpu"},
+				"RES2": {Resource: "limits.memory", Container: "main", Divisor: "1Mi"},
+			},
+			wantFileKeyRefs: map[string]FileKeyRef{
+				"FK": {Key: "MY_VAR", Path: "config.env", VolumeName: "config-vol"},
+			},
 			wantSecretKeys: []string{
 				"DATABASE_URL",
 				"DUPLICATE_TEST",
@@ -57,8 +83,7 @@ func TestMixedEnvVars_Interpolate(t *testing.T) {
 			},
 		},
 		{
-			// 3-hop chain: A → B → DATABASE_URL (secret)
-			// B gets promoted to secret in step 2; A must then also be promoted
+			name: "3-hop chain promotes to secret",
 			inputEnvVars: map[string]string{
 				"A": "{{ B }}",
 				"B": "{{ DATABASE_URL }}",
@@ -72,15 +97,70 @@ func TestMixedEnvVars_Interpolate(t *testing.T) {
 				"B":            "fake-db-url",
 				"DATABASE_URL": "fake-db-url",
 			},
-			wantSecretRefs: map[string]string{},
-			wantSecretKeys: []string{"A", "B", "DATABASE_URL"},
+			wantSecretRefs:        map[string]string{},
+			wantFieldRefs:         map[string]FieldRef{},
+			wantConfigMapRefs:     map[string]ConfigMapRef{},
+			wantResourceFieldRefs: map[string]ResourceFieldRef{},
+			wantFileKeyRefs:       map[string]FileKeyRef{},
+			wantSecretKeys:        []string{"A", "B", "DATABASE_URL"},
+		},
+		{
+			name: "unknown k8s template passes through",
+			inputEnvVars: map[string]string{
+				"FOO": "bar",
+				"UNK": "{{ k8s.future(a,b) }}",
+			},
+			inputSecrets:          map[string]string{},
+			wantEnvVars:           map[string]string{"FOO": "bar", "UNK": "{{ k8s.future(a,b) }}"},
+			wantSecrets:           map[string]string{},
+			wantSecretRefs:        map[string]string{},
+			wantFieldRefs:         map[string]FieldRef{},
+			wantConfigMapRefs:     map[string]ConfigMapRef{},
+			wantResourceFieldRefs: map[string]ResourceFieldRef{},
+			wantFileKeyRefs:       map[string]FileKeyRef{},
+			wantSecretKeys:        []string{},
+		},
+		{
+			name: "malformed k8s.field wrong arg count returns error",
+			inputEnvVars: map[string]string{
+				"BAD": "{{ k8s.field(only-one) }}",
+			},
+			inputSecrets: map[string]string{},
+			wantErrors:   1,
+		},
+		{
+			name: "malformed k8s.configMap returns error",
+			inputEnvVars: map[string]string{
+				"BAD": "{{ k8s.configMap(only-one) }}",
+			},
+			inputSecrets: map[string]string{},
+			wantErrors:   1,
+		},
+		{
+			name: "malformed k8s.fileKey returns error",
+			inputEnvVars: map[string]string{
+				"BAD": "{{ k8s.fileKey(one, two) }}",
+			},
+			inputSecrets: map[string]string{},
+			wantErrors:   1,
 		},
 	}
 
-	for i, test := range tests {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			got := NewEnvVars(test.inputEnvVars, test.inputSecrets)
-			got.Interpolate()
+			errs := got.Interpolate()
+
+			if test.wantErrors > 0 {
+				if len(errs) != test.wantErrors {
+					t.Errorf("expected %d errors, got %d: %v", test.wantErrors, len(errs), errs)
+				}
+				return
+			}
+			if len(errs) > 0 {
+				t.Fatalf("unexpected errors: %v", errs)
+			}
+
 			if diff := cmp.Diff(test.wantEnvVars, got.EnvVars()); diff != "" {
 				t.Errorf("mismatched env vars (-want, +got):\n%s", diff)
 			}
@@ -89,6 +169,18 @@ func TestMixedEnvVars_Interpolate(t *testing.T) {
 			}
 			if diff := cmp.Diff(test.wantSecretRefs, got.SecretRefs()); diff != "" {
 				t.Errorf("mismatched secret refs (-want, +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.wantFieldRefs, got.FieldRefs()); diff != "" {
+				t.Errorf("mismatched field refs (-want, +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.wantConfigMapRefs, got.ConfigMapRefs()); diff != "" {
+				t.Errorf("mismatched config map refs (-want, +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.wantResourceFieldRefs, got.ResourceFieldRefs()); diff != "" {
+				t.Errorf("mismatched resource field refs (-want, +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.wantFileKeyRefs, got.FileKeyRefs()); diff != "" {
+				t.Errorf("mismatched file key refs (-want, +got):\n%s", diff)
 			}
 			if diff := cmp.Diff(test.wantSecretKeys, got.SecretKeys()); diff != "" {
 				t.Errorf("mismatched secret keys (-want, +got):\n%s", diff)

--- a/specs/k8s-value-from.md
+++ b/specs/k8s-value-from.md
@@ -1,0 +1,223 @@
+# Spec: `ns_env_variables` support for K8s `valueFrom` templates
+
+## Background
+
+Nullstone modules accept environment variables as a flat `map(string)`. For Kubernetes workloads, some env vars need to be sourced from the K8s downward API, ConfigMaps, resource fields, or files rather than set as literal values. Today, the provider already supports a `{{ secret(...) }}` template syntax that gets parsed and routed to `secret_refs`. This spec extends the same pattern to four additional K8s `valueFrom` sources.
+
+## Template Syntax
+
+Users write these as values in the flat env var map:
+
+| Template | K8s `valueFrom` type | Example |
+|---|---|---|
+| `{{ k8s.field(<apiVersion>, <fieldPath>) }}` | `fieldRef` | `{{ k8s.field(v1, status.podIP) }}` |
+| `{{ k8s.configMap(<key>, <name>[, <optional>]) }}` | `configMapKeyRef` | `{{ k8s.configMap(my-key, my-cm, true) }}` |
+| `{{ k8s.resourceField(<resource>[, <container>, <divisor>]) }}` | `resourceFieldRef` | `{{ k8s.resourceField(limits.cpu) }}` |
+| `{{ k8s.fileKey(<key>, <path>, <volumeName>) }}` | `fileKeyRef` | `{{ k8s.fileKey(CONFIG_VAR, config.env, config-volume) }}` |
+
+All templates follow the existing convention: `{{ <namespace>.<type>(<args>) }}`. The `k8s.` namespace scopes these functions to Kubernetes workloads. The existing `secret(...)` function remains unnamespaced since it is provider-agnostic.
+
+### Argument details
+
+**`k8s.field(apiVersion, fieldPath)`**
+- `apiVersion` (required): e.g. `v1`
+- `fieldPath` (required): e.g. `status.podIP`, `metadata.name`, `metadata.namespace`
+
+**`k8s.configMap(key, name, optional)`**
+- `key` (required): The key within the ConfigMap
+- `name` (required): The ConfigMap name
+- `optional` (optional, default `false`): Whether the ConfigMap/key must exist. Accepts `true`/`false`.
+
+**`k8s.resourceField(resource, container, divisor)`**
+- `resource` (required): e.g. `limits.cpu`, `requests.memory`
+- `container` (optional): Container name; omit to use the current container
+- `divisor` (optional): Resource divisor; e.g. `1Mi`
+
+**`k8s.fileKey(key, path, volumeName)`** _(K8s 1.34+, alpha, requires `EnvFiles` feature gate)_
+- `key` (required): The key to read from the env file (file uses `KEY=VALUE` syntax)
+- `path` (required): Filename within the volume (e.g. `config.env`)
+- `volumeName` (required): Name of the `emptyDir` volume containing the file
+
+## Provider Changes
+
+### Parsing
+
+In the `ns_env_variables` data source read/compute logic, after processing `secret(...)` refs, scan remaining `input_env_variables` values for the four new patterns: `k8s.field(...)`, `k8s.configMap(...)`, `k8s.resourceField(...)`, `k8s.fileKey(...)`. Use the same `{{ ... }}` envelope detection. Strip matched entries from the plain `env_variables` output (same as secrets are stripped today).
+
+### New Outputs
+
+Add four new computed attributes to `ns_env_variables`:
+
+```
+field_refs: map of env var name => object
+  - api_version: string
+  - field_path:  string
+
+config_map_refs: map of env var name => object
+  - key:      string
+  - name:     string
+  - optional: bool
+
+resource_field_refs: map of env var name => object
+  - resource:  string
+  - container: string (empty string if omitted)
+  - divisor:   string (empty string if omitted)
+
+file_key_refs: map of env var name => object
+  - key:         string
+  - path:        string
+  - volume_name: string
+```
+
+All four outputs should be **non-sensitive**.
+
+### Schema definition (pseudocode)
+
+```go
+"field_refs": {
+    Type: schema.TypeMap,
+    Computed: true,
+    Elem: &schema.Resource{
+        Schema: map[string]*schema.Schema{
+            "api_version": {Type: schema.TypeString},
+            "field_path":  {Type: schema.TypeString},
+        },
+    },
+},
+"config_map_refs": {
+    Type: schema.TypeMap,
+    Computed: true,
+    Elem: &schema.Resource{
+        Schema: map[string]*schema.Schema{
+            "key":      {Type: schema.TypeString},
+            "name":     {Type: schema.TypeString},
+            "optional": {Type: schema.TypeBool},
+        },
+    },
+},
+"resource_field_refs": {
+    Type: schema.TypeMap,
+    Computed: true,
+    Elem: &schema.Resource{
+        Schema: map[string]*schema.Schema{
+            "resource":  {Type: schema.TypeString},
+            "container": {Type: schema.TypeString},
+            "divisor":   {Type: schema.TypeString},
+        },
+    },
+},
+"file_key_refs": {
+    Type: schema.TypeMap,
+    Computed: true,
+    Elem: &schema.Resource{
+        Schema: map[string]*schema.Schema{
+            "key":         {Type: schema.TypeString},
+            "path":        {Type: schema.TypeString},
+            "volume_name": {Type: schema.TypeString},
+        },
+    },
+},
+```
+
+### Filtering
+
+Entries matched by any of the four new patterns MUST be removed from the existing `env_variables` output so they are not also emitted as plain `value` env vars. This is the same filtering behavior already applied for `secret(...)` refs.
+
+### Error handling
+
+- Malformed templates (wrong number of args, empty args) should produce a diagnostic error at plan time with the env var name and the raw value.
+- Unknown template types inside `{{ ... }}` should be left as-is in `env_variables` (passthrough) so existing behavior is preserved and future types can be added without breaking.
+
+## Module Changes (consumer side)
+
+In `env_vars.tf`:
+
+```hcl
+locals {
+  env_var_field_refs          = data.ns_env_variables.this.field_refs
+  env_var_config_map_refs     = data.ns_env_variables.this.config_map_refs
+  env_var_resource_field_refs = data.ns_env_variables.this.resource_field_refs
+  env_var_file_key_refs       = data.ns_env_variables.this.file_key_refs
+}
+```
+
+In `deployment.tf`, replace the placeholder static `env` block (current lines 302-322) with:
+
+```hcl
+dynamic "env" {
+  for_each = local.env_var_field_refs
+  content {
+    name = env.key
+    value_from {
+      field_ref {
+        api_version = env.value.api_version
+        field_path  = env.value.field_path
+      }
+    }
+  }
+}
+
+dynamic "env" {
+  for_each = local.env_var_config_map_refs
+  content {
+    name = env.key
+    value_from {
+      config_map_key_ref {
+        key      = env.value.key
+        name     = env.value.name
+        optional = env.value.optional
+      }
+    }
+  }
+}
+
+dynamic "env" {
+  for_each = local.env_var_resource_field_refs
+  content {
+    name = env.key
+    value_from {
+      resource_field_ref {
+        resource       = env.value.resource
+        container_name = env.value.container
+        divisor        = env.value.divisor
+      }
+    }
+  }
+}
+
+# Requires K8s 1.34+ and EnvFiles feature gate
+dynamic "env" {
+  for_each = local.env_var_file_key_refs
+  content {
+    name = env.key
+    value_from {
+      file_key_ref {
+        key         = env.value.key
+        path        = env.value.path
+        volume_name = env.value.volume_name
+      }
+    }
+  }
+}
+```
+
+## Test Cases
+
+### Provider unit tests
+
+| Input | Expected output | Expected removed from `env_variables` |
+|---|---|---|
+| `FOO = "bar"` | No refs; `env_variables["FOO"] = "bar"` | No |
+| `IP = "{{ k8s.field(v1, status.podIP) }}"` | `field_refs["IP"] = {api_version: "v1", field_path: "status.podIP"}` | Yes |
+| `CM = "{{ k8s.configMap(key, name, true) }}"` | `config_map_refs["CM"] = {key: "key", name: "name", optional: true}` | Yes |
+| `CM2 = "{{ k8s.configMap(key, name) }}"` | `config_map_refs["CM2"] = {key: "key", name: "name", optional: false}` | Yes |
+| `RES = "{{ k8s.resourceField(limits.cpu) }}"` | `resource_field_refs["RES"] = {resource: "limits.cpu", container: "", divisor: ""}` | Yes |
+| `RES2 = "{{ k8s.resourceField(limits.memory, main, 1Mi) }}"` | `resource_field_refs["RES2"] = {resource: "limits.memory", container: "main", divisor: "1Mi"}` | Yes |
+| `FK = "{{ k8s.fileKey(MY_VAR, config.env, config-vol) }}"` | `file_key_refs["FK"] = {key: "MY_VAR", path: "config.env", volume_name: "config-vol"}` | Yes |
+| `SEC = "{{ secret(my-secret) }}"` | Existing `secret_refs` behavior unchanged | Yes |
+| `BAD = "{{ k8s.field() }}"` | Plan-time error: missing required args | N/A |
+| `UNK = "{{ k8s.future(a,b) }}"` | No refs; `env_variables["UNK"] = "{{ k8s.future(a,b) }}"` (passthrough) | No |
+
+### Integration / acceptance tests
+
+- Deploy with a mix of plain, secret, field_ref, config_map_ref, resource_field_ref, and file_key_ref env vars and verify the resulting K8s pod spec has the correct env structure.

--- a/website/docs/d/env_variables.markdown
+++ b/website/docs/d/env_variables.markdown
@@ -1,0 +1,131 @@
+---
+layout: "ns"
+page_title: "Nullstone: ns_env_variables"
+sidebar_current: "docs-ns-env-variables"
+description: |-
+  Data source to interpolate environment variables and secrets into their final values.
+---
+
+# ns_env_variables
+
+Data source to interpolate environment variables and secrets into their final values.
+It resolves `{{ VAR }}` references between variables, promotes variables to secrets when they reference a secret, and extracts special template syntax for secret refs and Kubernetes `valueFrom` sources.
+
+## Example Usage
+
+#### Basic example
+
+```hcl
+data "ns_env_variables" "this" {
+  input_env_variables = {
+    NULLSTONE_STACK = "primary"
+    NULLSTONE_BLOCK = "acme-api"
+    NULLSTONE_ENV   = "dev"
+    IDENTIFIER      = "{{ NULLSTONE_STACK }}.{{ NULLSTONE_BLOCK }}.{{ NULLSTONE_ENV }}"
+    DATABASE_URL    = "{{ POSTGRES_URL }}"
+  }
+  input_secrets = {
+    POSTGRES_URL = "postgres://user:pass@host:5432/mydb"
+  }
+}
+```
+
+After interpolation:
+- `env_variables["IDENTIFIER"]` = `"primary.acme-api.dev"`
+- `secrets["DATABASE_URL"]` = `"postgres://user:pass@host:5432/mydb"` (promoted because it references a secret)
+
+#### Secret ref example
+
+```hcl
+data "ns_env_variables" "this" {
+  input_env_variables = {
+    MY_SECRET = "{{ secret(arn:aws:secretsmanager:us-east-1:123456789:secret:my-secret) }}"
+  }
+  input_secrets = {}
+}
+```
+
+- `secret_refs["MY_SECRET"]` = `"arn:aws:secretsmanager:us-east-1:123456789:secret:my-secret"`
+
+#### Kubernetes valueFrom example
+
+```hcl
+data "ns_env_variables" "this" {
+  input_env_variables = {
+    POD_IP    = "{{ k8s.field(v1, status.podIP) }}"
+    APP_CFG   = "{{ k8s.configMap(app-key, my-configmap, true) }}"
+    CPU_LIMIT = "{{ k8s.resourceField(limits.cpu) }}"
+    FILE_VAR  = "{{ k8s.fileKey(MY_VAR, config.env, config-vol) }}"
+  }
+  input_secrets = {}
+}
+```
+
+- `field_refs["POD_IP"]` = `{ api_version = "v1", field_path = "status.podIP" }`
+- `config_map_refs["APP_CFG"]` = `{ key = "app-key", name = "my-configmap", optional = true }`
+- `resource_field_refs["CPU_LIMIT"]` = `{ resource = "limits.cpu", container = "", divisor = "" }`
+- `file_key_refs["FILE_VAR"]` = `{ key = "MY_VAR", path = "config.env", volume_name = "config-vol" }`
+
+## Template Syntax
+
+Values in `input_env_variables` can use the following template patterns:
+
+| Template | Description | Example |
+|---|---|---|
+| `{{ VAR_NAME }}` | Interpolate another variable's value | `{{ POSTGRES_URL }}` |
+| `{{ secret(<ref>) }}` | Reference an external secret | `{{ secret(arn:aws:...) }}` |
+| `{{ k8s.field(<apiVersion>, <fieldPath>) }}` | Kubernetes `fieldRef` | `{{ k8s.field(v1, status.podIP) }}` |
+| `{{ k8s.configMap(<key>, <name>[, <optional>]) }}` | Kubernetes `configMapKeyRef` | `{{ k8s.configMap(my-key, my-cm, true) }}` |
+| `{{ k8s.resourceField(<resource>[, <container>, <divisor>]) }}` | Kubernetes `resourceFieldRef` | `{{ k8s.resourceField(limits.cpu) }}` |
+| `{{ k8s.fileKey(<key>, <path>, <volumeName>) }}` | Kubernetes `fileKeyRef` | `{{ k8s.fileKey(MY_VAR, config.env, config-vol) }}` |
+
+### Template argument details
+
+**`k8s.field(apiVersion, fieldPath)`**
+- `apiVersion` (required): e.g. `v1`
+- `fieldPath` (required): e.g. `status.podIP`, `metadata.name`, `metadata.namespace`
+
+**`k8s.configMap(key, name, optional)`**
+- `key` (required): The key within the ConfigMap
+- `name` (required): The ConfigMap name
+- `optional` (optional, default `false`): Whether the ConfigMap/key must exist. Accepts `true`/`false`.
+
+**`k8s.resourceField(resource, container, divisor)`**
+- `resource` (required): e.g. `limits.cpu`, `requests.memory`
+- `container` (optional): Container name; omit to use the current container
+- `divisor` (optional): Resource divisor; e.g. `1Mi`
+
+**`k8s.fileKey(key, path, volumeName)`** _(K8s 1.34+, alpha, requires `EnvFiles` feature gate)_
+- `key` (required): The key to read from the env file
+- `path` (required): Filename within the volume (e.g. `config.env`)
+- `volumeName` (required): Name of the volume containing the file
+
+Entries matched by `secret(...)` or any `k8s.*` template are removed from `env_variables` and appear only in their respective ref output. Unknown template types (e.g. `{{ k8s.future(a,b) }}`) are left as-is in `env_variables`.
+
+Malformed templates (wrong number of arguments, empty arguments) produce a diagnostic error at plan time.
+
+## Arguments Reference
+
+* `input_env_variables` - (Required) A map of environment variable names to their raw values before interpolation.
+* `input_secrets` - (Required, Sensitive) A map of secret names to their raw values before interpolation.
+
+## Attributes Reference
+
+* `env_variables` - A map of non-sensitive environment variables after interpolation. Variables that were promoted to secrets or matched a template pattern are excluded.
+* `secrets` - (Sensitive) A map of secret environment variables after interpolation. Includes original secrets and any variables promoted to secrets by referencing a secret.
+* `secret_refs` - A map of environment variable names to their extracted secret reference strings (from `{{ secret(...) }}`).
+* `field_refs` - A map of environment variable names to objects with:
+    * `api_version` - The Kubernetes API version (e.g. `v1`).
+    * `field_path` - The field path (e.g. `status.podIP`).
+* `config_map_refs` - A map of environment variable names to objects with:
+    * `key` - The key within the ConfigMap.
+    * `name` - The ConfigMap name.
+    * `optional` - Whether the ConfigMap/key must exist (`true`/`false`).
+* `resource_field_refs` - A map of environment variable names to objects with:
+    * `resource` - The resource name (e.g. `limits.cpu`).
+    * `container` - The container name (empty string if omitted).
+    * `divisor` - The resource divisor (empty string if omitted).
+* `file_key_refs` - A map of environment variable names to objects with:
+    * `key` - The key to read from the env file.
+    * `path` - The filename within the volume.
+    * `volume_name` - The name of the volume containing the file.


### PR DESCRIPTION
This adds support for special functions in an env var (similar to `{{ secret() }}`) that enables usage of k8s `valueFrom`.

| Template | K8s `valueFrom` type | Example |
|---|---|---|
| `{{ k8s.field(<apiVersion>, <fieldPath>) }}` | `fieldRef` | `{{ k8s.field(v1, status.podIP) }}` |
| `{{ k8s.configMap(<key>, <name>[, <optional>]) }}` | `configMapKeyRef` | `{{ k8s.configMap(my-key, my-cm, true) }}` |
| `{{ k8s.resourceField(<resource>[, <container>, <divisor>]) }}` | `resourceFieldRef` | `{{ k8s.resourceField(limits.cpu) }}` |
| `{{ k8s.fileKey(<key>, <path>, <volumeName>) }}` | `fileKeyRef` | `{{ k8s.fileKey(CONFIG_VAR, config.env, config-volume) }}` |

When a user specifies one of the above, the structured objects are included in new attributes on `data.ns_env_variables`:
- `field_refs`
- `config_map_refs`
- `resource_field_refs`
- `file_key_refs`

Also, those are removed from `env_variables` attribute on `data.ns_env_variables` since they're not "plain" values.