### PR TITLE
Feat/85/cap name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.10.0 (Jun 10, 2026)
+
+FEATURES:
+
+* Added `ns_capability` data source that enables retrieval of information about the current capability.
+
 ## 0.9.0 (Apr 30, 2026)
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 
 * Added `ns_capability` data source that enables retrieval of information about the current capability.
+* Added missing site docs for `ns_agent` and `ns_secret_keys`. 
 
 ## 0.9.0 (Apr 30, 2026)
 

--- a/internal/provider/data_capability.go
+++ b/internal/provider/data_capability.go
@@ -1,0 +1,60 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+type dataCapability struct {
+	p *provider
+}
+
+func newDataCapability(p *provider) (*dataCapability, error) {
+	if p == nil {
+		return nil, fmt.Errorf("a provider is required")
+	}
+	return &dataCapability{p: p}, nil
+}
+
+func (*dataCapability) Schema(ctx context.Context) *tfprotov5.Schema {
+	return &tfprotov5.Schema{
+		Version: 1,
+		Block: &tfprotov5.SchemaBlock{
+			Description:     "Data source to read the current nullstone capability.",
+			DescriptionKind: tfprotov5.StringKindMarkdown,
+			Attributes: []*tfprotov5.SchemaAttribute{
+				{
+					Name:            "id",
+					Type:            tftypes.Number,
+					Description:     "The ID of the capability this module is deployed as.",
+					DescriptionKind: tfprotov5.StringKindMarkdown,
+					Computed:        true,
+				},
+				{
+					Name:            "name",
+					Type:            tftypes.String,
+					Description:     "The name of the capability this module is deployed as.",
+					DescriptionKind: tfprotov5.StringKindMarkdown,
+					Computed:        true,
+				},
+			},
+		},
+	}
+}
+
+func (d *dataCapability) Validate(ctx context.Context, config map[string]tftypes.Value) ([]*tfprotov5.Diagnostic, error) {
+	return nil, nil
+}
+
+func (d *dataCapability) Read(ctx context.Context, config map[string]tftypes.Value) (map[string]tftypes.Value, []*tfprotov5.Diagnostic, error) {
+	planConfig := d.p.PlanConfig
+
+	capabilityId := planConfig.CapabilityId
+
+	return map[string]tftypes.Value{
+		"id":   tftypes.NewValue(tftypes.Number, &capabilityId),
+		"name": tftypes.NewValue(tftypes.String, planConfig.CapabilityName),
+	}, nil, nil
+}

--- a/internal/provider/data_capability_test.go
+++ b/internal/provider/data_capability_test.go
@@ -1,0 +1,38 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestDataCapability(t *testing.T) {
+	t.Run("reads capability from plan config", func(t *testing.T) {
+		config := fmt.Sprintf(`
+provider "ns" {
+  organization    = "org0"
+  capability_id   = "123"
+  capability_name = "my-capability"
+}
+data "ns_capability" "this" {}
+`)
+		getNsConfig, _ := mockNs(nil)
+		getTfeConfig, _ := mockTfe(nil)
+
+		checks := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("data.ns_capability.this", "id", "123"),
+			resource.TestCheckResourceAttr("data.ns_capability.this", "name", "my-capability"),
+		)
+
+		resource.UnitTest(t, resource.TestCase{
+			ProtoV5ProviderFactories: protoV5ProviderFactories(getNsConfig, getTfeConfig, nil),
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check:  checks,
+				},
+			},
+		})
+	})
+}

--- a/internal/provider/data_workspace.go
+++ b/internal/provider/data_workspace.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -72,13 +73,6 @@ This is typically used to construct unique resource names. See unique_name.`,
 			Computed:        true,
 		},
 		{
-			Name:            "capability_name",
-			Type:            tftypes.String,
-			Computed:        true,
-			Description:     "The name of the capability this module is deployed as. Empty when not running as a capability.",
-			DescriptionKind: tfprotov5.StringKindMarkdown,
-		},
-		{
 			Name:            "tags",
 			Type:            tftypes.Map{ElementType: tftypes.String},
 			Computed:        true,
@@ -143,15 +137,14 @@ func (d *dataWorkspace) Read(ctx context.Context, config map[string]tftypes.Valu
 	}
 
 	return map[string]tftypes.Value{
-		"id":              tftypes.NewValue(tftypes.String, id),
-		"stack_id":        tftypes.NewValue(tftypes.Number, &stackId),
-		"stack_name":      tftypes.NewValue(tftypes.String, stackName),
-		"block_id":        tftypes.NewValue(tftypes.Number, &blockId),
-		"block_name":      tftypes.NewValue(tftypes.String, blockName),
-		"block_ref":       tftypes.NewValue(tftypes.String, blockRef),
-		"env_id":          tftypes.NewValue(tftypes.Number, &envId),
-		"env_name":        tftypes.NewValue(tftypes.String, envName),
-		"capability_name": tftypes.NewValue(tftypes.String, planConfig.CapabilityName),
-		"tags":            tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, tags),
+		"id":         tftypes.NewValue(tftypes.String, id),
+		"stack_id":   tftypes.NewValue(tftypes.Number, &stackId),
+		"stack_name": tftypes.NewValue(tftypes.String, stackName),
+		"block_id":   tftypes.NewValue(tftypes.Number, &blockId),
+		"block_name": tftypes.NewValue(tftypes.String, blockName),
+		"block_ref":  tftypes.NewValue(tftypes.String, blockRef),
+		"env_id":     tftypes.NewValue(tftypes.Number, &envId),
+		"env_name":   tftypes.NewValue(tftypes.String, envName),
+		"tags":       tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, tags),
 	}, nil, nil
 }

--- a/internal/provider/data_workspace.go
+++ b/internal/provider/data_workspace.go
@@ -72,6 +72,13 @@ This is typically used to construct unique resource names. See unique_name.`,
 			Computed:        true,
 		},
 		{
+			Name:            "capability_name",
+			Type:            tftypes.String,
+			Computed:        true,
+			Description:     "The name of the capability this module is deployed as. Empty when not running as a capability.",
+			DescriptionKind: tfprotov5.StringKindMarkdown,
+		},
+		{
 			Name:            "tags",
 			Type:            tftypes.Map{ElementType: tftypes.String},
 			Computed:        true,
@@ -136,14 +143,15 @@ func (d *dataWorkspace) Read(ctx context.Context, config map[string]tftypes.Valu
 	}
 
 	return map[string]tftypes.Value{
-		"id":         tftypes.NewValue(tftypes.String, id),
-		"stack_id":   tftypes.NewValue(tftypes.Number, &stackId),
-		"stack_name": tftypes.NewValue(tftypes.String, stackName),
-		"block_id":   tftypes.NewValue(tftypes.Number, &blockId),
-		"block_name": tftypes.NewValue(tftypes.String, blockName),
-		"block_ref":  tftypes.NewValue(tftypes.String, blockRef),
-		"env_id":     tftypes.NewValue(tftypes.Number, &envId),
-		"env_name":   tftypes.NewValue(tftypes.String, envName),
-		"tags":       tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, tags),
+		"id":              tftypes.NewValue(tftypes.String, id),
+		"stack_id":        tftypes.NewValue(tftypes.Number, &stackId),
+		"stack_name":      tftypes.NewValue(tftypes.String, stackName),
+		"block_id":        tftypes.NewValue(tftypes.Number, &blockId),
+		"block_name":      tftypes.NewValue(tftypes.String, blockName),
+		"block_ref":       tftypes.NewValue(tftypes.String, blockRef),
+		"env_id":          tftypes.NewValue(tftypes.Number, &envId),
+		"env_name":        tftypes.NewValue(tftypes.String, envName),
+		"capability_name": tftypes.NewValue(tftypes.String, planConfig.CapabilityName),
+		"tags":            tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, tags),
 	}, nil, nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -158,8 +158,12 @@ func (p *provider) Configure(ctx context.Context, config map[string]tftypes.Valu
 	p.NsConfig.OrgName = p.PlanConfig.OrgName
 	log.Printf("[DEBUG] Configured Nullstone API client (Address=%s)\n", p.NsConfig.BaseAddress)
 
-	p.PlanConfig.CapabilityName = extractStringFromConfig(config, "capability_name")
-	log.Printf("[DEBUG] capability_name set to %s\n", p.PlanConfig.CapabilityName)
+	p.PlanConfig.CapabilityId = extractInt64FromConfig(config, "capability_id")
+	log.Printf("[DEBUG] capability_id set to %d\n", p.PlanConfig.CapabilityId)
+	if capName := extractStringFromConfig(config, "capability_name"); capName != "" {
+		p.PlanConfig.CapabilityName = capName
+	}
+	log.Printf("[DEBUG] capability_name set to %q\n", p.PlanConfig.CapabilityName)
 
 	p.TfeClient, err = tfe.NewClient(p.TfeConfig)
 	if err != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -59,6 +59,7 @@ func newProviderServer(version string, fn func() (api.Config, *tfe.Config, PlanC
 	s.MustRegisterDataSource("ns_secret_keys", newDataSecretKeys)
 	s.MustRegisterDataSource("ns_env", newDataEnv)
 	s.MustRegisterDataSource("ns_agent", newDataAgent)
+	s.MustRegisterDataSource("ns_capability", newDataCapability)
 
 	// resources
 	s.MustRegisterResource("ns_autogen_subdomain", newResourceAutogenSubdomain)

--- a/website/docs/d/agent.markdown
+++ b/website/docs/d/agent.markdown
@@ -1,0 +1,36 @@
+---
+layout: "ns"
+page_title: "Nullstone: ns_agent"
+sidebar_current: "docs-ns-agent"
+description: |-
+  Data source to read information about the Nullstone Agent.
+---
+
+# ns_agent
+
+Data source to read information about the Nullstone Agent.
+
+This is typically used to grant the Nullstone Agent access to cloud resources (for example, by referencing its AWS user ARN or GCP service account email in an IAM policy).
+
+## Example Usage
+
+```hcl
+data "ns_agent" "this" {
+}
+
+locals {
+  agent_aws_user_arn = data.ns_agent.this.aws_user_arn
+}
+```
+
+## Argument Reference
+
+There are no arguments to this data source.
+
+## Attributes Reference
+
+* `aws_account_id` (string) - The AWS Account ID of the Nullstone Agent.
+* `aws_user_name` (string) - The AWS User Name of the Nullstone Agent.
+* `aws_user_arn` (string) - The AWS User ARN of the Nullstone Agent.
+* `gcp_project_id` (string) - The GCP Project ID of the Nullstone Agent.
+* `gcp_service_account_email` (string) - The GCP Service Account Email of the Nullstone Agent.

--- a/website/docs/d/capability.html.markdown
+++ b/website/docs/d/capability.html.markdown
@@ -1,0 +1,31 @@
+---
+layout: "ns"
+page_title: "Nullstone: ns_capability"
+sidebar_current: "docs-ns-capability"
+description: |-
+  Data source to read the current nullstone capability.
+---
+
+# ns_capability
+
+Data source to read the current nullstone capability.
+
+This data source is affected by Plan Config. See [the main provider documentation](../index.html) for more details.
+It reads the `id` and `name` of the capability the module is currently deployed as.
+These are empty/zero when the module is not running as a capability.
+
+## Example Usage
+
+```hcl
+data "ns_capability" "this" {
+}
+```
+
+## Argument Reference
+
+There are no arguments to this data source.
+
+## Attributes Reference
+
+* `id` (number) - The ID of the capability this module is deployed as.
+* `name` (string) - The name of the capability this module is deployed as.

--- a/website/docs/d/secret_keys.markdown
+++ b/website/docs/d/secret_keys.markdown
@@ -1,0 +1,43 @@
+---
+layout: "ns"
+page_title: "Nullstone: ns_secret_keys"
+sidebar_current: "docs-ns-secret-keys"
+description: |-
+  Data source to compute the full set of secret keys after interpolation.
+---
+
+# ns_secret_keys
+
+Data source to compute the full set of secret keys after interpolation.
+
+It interpolates `{{ VAR }}` references between environment variables and secrets, then returns the keys of every value that resolves to a secret.
+A variable is promoted to a secret when it references one of the `input_secret_keys`.
+Unlike [`ns_env_variables`](env_variables.html), this data source only exposes the secret *keys* — never their values — so it can be used safely where the secret values are not yet known.
+
+## Example Usage
+
+```hcl
+data "ns_secret_keys" "this" {
+  input_env_variables = {
+    DATABASE_URL = "{{ POSTGRES_URL }}"
+    LOG_LEVEL    = "info"
+  }
+  input_secret_keys = [
+    "POSTGRES_URL",
+  ]
+}
+```
+
+After interpolation:
+- `secret_keys` = `["DATABASE_URL", "POSTGRES_URL"]` (`DATABASE_URL` is promoted because it references a secret; keys are sorted alphabetically)
+
+## Arguments Reference
+
+* `input_env_variables` - (Required) A map of environment variable names to their raw values before interpolation.
+* `input_secret_keys` - (Required, Sensitive) A set of secret key names before interpolation.
+
+Keys in `input_env_variables` and `input_secret_keys` must contain only letters, numbers, and underscores, and may not begin with a number.
+
+## Attributes Reference
+
+* `secret_keys` - The set of all keys that resolve to a secret. Includes the original `input_secret_keys` plus any variables promoted to secrets by referencing a secret.


### PR DESCRIPTION
This adds a new datasource `ns_capability` to retrieve info about the capability, particularly `name`.
This also backfills missing site docs for `ns_agent` and `ns_secret_keys`.